### PR TITLE
Add documentation website with three static HTML pages

### DIFF
--- a/docs/best_practices.html
+++ b/docs/best_practices.html
@@ -1,0 +1,742 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Best Practices - xlfilldown</title>
+<meta name="description" content="Best practice recipes and usage patterns for xlfilldown: Flask integration, pipeline automation, data quality checks, and more.">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #1a1a2e;
+  line-height: 1.7;
+  background: #fff;
+}
+a { color: #2563eb; text-decoration: none; }
+a:hover { text-decoration: underline; }
+code, pre { font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Consolas', monospace; }
+
+.site-header {
+  position: sticky; top: 0; z-index: 100;
+  background: linear-gradient(135deg, #1a1a2e, #16213e, #0f3460);
+  padding: 0 24px;
+  box-shadow: 0 2px 12px rgba(0,0,0,0.3);
+}
+.header-inner {
+  max-width: 1100px; margin: 0 auto;
+  display: flex; align-items: center; justify-content: space-between; height: 60px;
+}
+.logo { font-size: 1.25rem; font-weight: 700; color: #fff; letter-spacing: -0.5px; }
+.logo span { color: #60a5fa; }
+nav { display: flex; gap: 24px; align-items: center; }
+nav a { color: #cbd5e1; font-size: 0.9rem; font-weight: 500; transition: color 0.2s; text-decoration: none; }
+nav a:hover, nav a.active { color: #fff; text-decoration: none; }
+.nav-toggle { display: none; background: none; border: none; cursor: pointer; padding: 4px; }
+.nav-toggle span { display: block; width: 22px; height: 2px; background: #cbd5e1; margin: 5px 0; }
+
+.page-banner {
+  background: linear-gradient(135deg, #1a1a2e, #16213e, #0f3460);
+  padding: 56px 24px 48px; text-align: center;
+}
+.page-banner h1 { font-size: 2.4rem; font-weight: 700; color: #fff; margin-bottom: 8px; }
+.page-banner p { color: #94a3b8; font-size: 1.05rem; max-width: 600px; margin: 0 auto; }
+
+.content { max-width: 960px; margin: 0 auto; padding: 48px 24px 72px; }
+
+code.inline {
+  background: #e2e8f0; color: #1e293b; padding: 2px 8px; border-radius: 4px; font-size: 0.85em;
+}
+pre.code-block {
+  background: #1e293b; color: #e2e8f0; border-radius: 10px;
+  padding: 20px 24px; overflow-x: auto; font-size: 0.85rem; line-height: 1.7; margin-bottom: 0;
+}
+.kw, .keyword { color: #93c5fd; }
+.fn { color: #fbbf24; }
+.st, .string { color: #86efac; }
+.cm, .comment { color: #64748b; }
+.op { color: #f472b6; }
+.nb { color: #c4b5fd; }
+
+/* Recipe cards */
+.recipe {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 28px;
+  margin-bottom: 28px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.04);
+}
+.recipe h3 {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: #1e3a5f;
+  margin-bottom: 8px;
+}
+.recipe p {
+  color: #475569;
+  font-size: 0.93rem;
+  margin-bottom: 14px;
+}
+.recipe p:last-child { margin-bottom: 0; }
+
+/* Tags */
+.tag {
+  display: inline-block;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 3px 10px;
+  border-radius: 20px;
+  margin-bottom: 12px;
+}
+.tag-cli { background: #dbeafe; color: #1e40af; }
+.tag-python { background: #fef3c7; color: #92400e; }
+.tag-pipeline { background: #dcfce7; color: #166534; }
+.tag-pattern { background: #ede9fe; color: #5b21b6; }
+.tag-quality { background: #fce7f3; color: #9d174d; }
+.tag-integration { background: #ffedd5; color: #9a3412; }
+
+h2 {
+  font-size: 1.6rem; font-weight: 700; color: #1e3a5f;
+  margin-top: 56px; margin-bottom: 20px;
+  padding-bottom: 12px; border-bottom: 2px solid #e2e8f0;
+}
+h2:first-of-type { margin-top: 0; }
+
+.section-intro {
+  color: #64748b;
+  font-size: 0.95rem;
+  margin-bottom: 28px;
+}
+
+/* Summary table */
+.ref-table { width: 100%; border-collapse: collapse; margin-bottom: 24px; font-size: 0.88rem; }
+.ref-table th {
+  background: #1e3a5f; color: #fff; font-weight: 600;
+  padding: 10px 14px; text-align: left; font-size: 0.85rem;
+}
+.ref-table td { padding: 10px 14px; border-bottom: 1px solid #e2e8f0; color: #374151; vertical-align: top; }
+.ref-table tr:nth-child(even) td { background: #f1f5f9; }
+.ref-table tr:hover td { background: #e8f0fe; }
+
+.note {
+  background: #f0f9ff; border-left: 4px solid #2563eb;
+  padding: 16px 20px; border-radius: 0 8px 8px 0; margin-bottom: 20px;
+}
+.note p { margin-bottom: 0; color: #1e3a5f; font-size: 0.9rem; }
+
+.site-footer {
+  background: linear-gradient(135deg, #1a1a2e, #16213e, #0f3460);
+  padding: 48px 24px 32px; color: #94a3b8; font-size: 0.85rem;
+}
+.footer-inner { max-width: 1100px; margin: 0 auto; display: grid; grid-template-columns: 2fr 1fr 1fr; gap: 40px; }
+.footer-brand h3 { color: #fff; font-size: 1.1rem; margin-bottom: 8px; }
+.footer-brand h3 span { color: #60a5fa; }
+.footer-links h4 { color: #cbd5e1; font-size: 0.9rem; margin-bottom: 12px; }
+.footer-links a { color: #94a3b8; display: block; margin-bottom: 6px; font-size: 0.85rem; }
+.footer-links a:hover { color: #fff; text-decoration: none; }
+.footer-bottom {
+  max-width: 1100px; margin: 32px auto 0; padding-top: 24px;
+  border-top: 1px solid rgba(255,255,255,0.1);
+  display: flex; justify-content: space-between; flex-wrap: wrap; gap: 12px;
+}
+.disclaimer { color: #64748b; font-size: 0.78rem; max-width: 600px; line-height: 1.5; }
+
+@media (max-width: 768px) {
+  .page-banner h1 { font-size: 1.8rem; }
+  .content { padding: 32px 16px 48px; }
+  .recipe { padding: 20px; }
+  .footer-inner { grid-template-columns: 1fr; gap: 24px; }
+  .footer-bottom { flex-direction: column; text-align: center; }
+  .nav-toggle { display: block; }
+  nav.nav-closed { display: none; }
+  nav.nav-open { display: flex; width: 100%; padding: 12px 0; flex-wrap: wrap; justify-content: center; }
+  h2 { font-size: 1.35rem; }
+}
+</style>
+</head>
+<body>
+
+<header class="site-header">
+  <div class="header-inner">
+    <a href="index.html" class="logo">xlf<span>ill</span>down</a>
+    <button class="nav-toggle" onclick="document.querySelector('nav').classList.toggle('nav-open');document.querySelector('nav').classList.toggle('nav-closed')" aria-label="Toggle navigation">
+      <span></span><span></span><span></span>
+    </button>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="reference.html">Reference</a>
+      <a href="best_practices.html" class="active">Best Practices</a>
+      <a href="https://github.com/RexBytes/xlfilldown">GitHub</a>
+      <a href="https://pypi.org/project/xlfilldown/">PyPI</a>
+    </nav>
+  </div>
+</header>
+
+<section class="page-banner">
+  <h1>Best Practices</h1>
+  <p>Recipes, patterns, and integration guides for getting the most out of xlfilldown.</p>
+</section>
+
+<div class="content">
+
+  <!-- CLI Recipes -->
+  <h2>CLI Recipes</h2>
+  <p class="section-intro">Common command-line patterns for everyday use.</p>
+
+  <div class="recipe">
+    <span class="tag tag-cli">CLI</span>
+    <h3>Basic hierarchical fill to SQLite</h3>
+    <p>The most common use case: a grouped .xlsx export with Region/Country/City hierarchy. Fill down, add audit columns, and load into SQLite.</p>
+    <pre class="code-block"><span class="prompt" style="color:#64748b">$</span> xlfilldown db \
+    <span class="op">--infile</span> <span class="string">quarterly_sales.xlsx</span> \
+    <span class="op">--insheet</span> <span class="string">"Q4 Data"</span> \
+    <span class="op">--header-row</span> <span class="nb">1</span> \
+    <span class="op">--fill-cols</span> <span class="string">'["Region","Country","City"]'</span> \
+    <span class="op">--db</span> <span class="string">sales.db</span> \
+    <span class="op">--row-hash</span> \
+    <span class="op">--excel-row-numbers</span> \
+    <span class="op">--drop-blank-rows</span></pre>
+  </div>
+
+  <div class="recipe">
+    <span class="tag tag-cli">CLI</span>
+    <h3>Independent fill using column letters</h3>
+    <p>When columns are independent (not hierarchical), use independent mode. Reference columns by their Excel letter instead of header names - useful when headers are long or contain special characters.</p>
+    <pre class="code-block"><span class="prompt" style="color:#64748b">$</span> xlfilldown xlsx \
+    <span class="op">--infile</span> <span class="string">inventory.xlsx</span> \
+    <span class="op">--insheet</span> <span class="string">"Stock"</span> \
+    <span class="op">--header-row</span> <span class="nb">1</span> \
+    <span class="op">--fill-cols-letters</span> <span class="nb">A C E</span> \
+    <span class="op">--fill-mode</span> <span class="string">independent</span> \
+    <span class="op">--outfile</span> <span class="string">inventory_filled.xlsx</span></pre>
+  </div>
+
+  <div class="recipe">
+    <span class="tag tag-cli">CLI</span>
+    <h3>Replace an existing table on re-run</h3>
+    <p>When running the same ingest repeatedly (e.g. weekly report refresh), use <code class="inline">--if-exists replace</code> to drop and recreate the table each time.</p>
+    <pre class="code-block"><span class="prompt" style="color:#64748b">$</span> xlfilldown db \
+    <span class="op">--infile</span> <span class="string">weekly_report.xlsx</span> \
+    <span class="op">--insheet</span> <span class="string">"Data"</span> \
+    <span class="op">--header-row</span> <span class="nb">1</span> \
+    <span class="op">--fill-cols</span> <span class="string">'["Department","Team"]'</span> \
+    <span class="op">--db</span> <span class="string">reports.db</span> \
+    <span class="op">--table</span> <span class="string">weekly_headcount</span> \
+    <span class="op">--if-exists</span> <span class="string">replace</span></pre>
+  </div>
+
+  <div class="recipe">
+    <span class="tag tag-cli">CLI</span>
+    <h3>Append incremental data</h3>
+    <p>For incremental loads where each run adds new rows (e.g. monthly exports appended to an annual table).</p>
+    <pre class="code-block"><span class="prompt" style="color:#64748b">$</span> xlfilldown db \
+    <span class="op">--infile</span> <span class="string">march_data.xlsx</span> \
+    <span class="op">--insheet</span> <span class="string">"Sheet1"</span> \
+    <span class="op">--header-row</span> <span class="nb">1</span> \
+    <span class="op">--fill-cols</span> <span class="string">'["Category","Subcategory"]'</span> \
+    <span class="op">--db</span> <span class="string">annual.db</span> \
+    <span class="op">--table</span> <span class="string">transactions</span> \
+    <span class="op">--row-hash</span> \
+    <span class="op">--excel-row-numbers</span> \
+    <span class="op">--if-exists</span> <span class="string">append</span></pre>
+    <div class="note">
+      <p><strong>Note:</strong> When appending, the existing table schema must exactly match the expected columns (including <code class="inline">row_hash</code> and <code class="inline">excel_row</code> if enabled). xlfilldown validates this before inserting.</p>
+    </div>
+  </div>
+
+  <div class="recipe">
+    <span class="tag tag-cli">CLI</span>
+    <h3>Raw ingest for audit baseline</h3>
+    <p>Load a sheet exactly as-is (no fill-down) but with audit columns. Useful for keeping a raw copy alongside the filled version for comparison.</p>
+    <pre class="code-block"><span class="comment"># Raw copy</span>
+<span class="prompt" style="color:#64748b">$</span> xlfilldown db \
+    <span class="op">--infile</span> <span class="string">data.xlsx</span> <span class="op">--insheet</span> <span class="string">"Sheet1"</span> <span class="op">--header-row</span> <span class="nb">1</span> \
+    <span class="op">--ingest-mode</span> <span class="string">raw</span> \
+    <span class="op">--db</span> <span class="string">audit.db</span> <span class="op">--table</span> <span class="string">raw_data</span> \
+    <span class="op">--row-hash</span> <span class="op">--excel-row-numbers</span> <span class="op">--if-exists</span> <span class="string">replace</span>
+
+<span class="comment"># Filled copy in the same database</span>
+<span class="prompt" style="color:#64748b">$</span> xlfilldown db \
+    <span class="op">--infile</span> <span class="string">data.xlsx</span> <span class="op">--insheet</span> <span class="string">"Sheet1"</span> <span class="op">--header-row</span> <span class="nb">1</span> \
+    <span class="op">--fill-cols</span> <span class="string">'["Region","Country"]'</span> \
+    <span class="op">--db</span> <span class="string">audit.db</span> <span class="op">--table</span> <span class="string">filled_data</span> \
+    <span class="op">--row-hash</span> <span class="op">--excel-row-numbers</span> <span class="op">--if-exists</span> <span class="string">replace</span></pre>
+  </div>
+
+  <div class="recipe">
+    <span class="tag tag-cli">CLI</span>
+    <h3>Filter rows with require-non-null</h3>
+    <p>Drop rows where critical columns are blank after filling. Combine with <code class="inline">--drop-blank-rows</code> to also remove spacer rows.</p>
+    <pre class="code-block"><span class="prompt" style="color:#64748b">$</span> xlfilldown db \
+    <span class="op">--infile</span> <span class="string">report.xlsx</span> \
+    <span class="op">--insheet</span> <span class="string">"Financials"</span> \
+    <span class="op">--header-row</span> <span class="nb">3</span> \
+    <span class="op">--fill-cols</span> <span class="string">'["Division","BU"]'</span> \
+    <span class="op">--drop-blank-rows</span> \
+    <span class="op">--require-non-null</span> <span class="string">'["Division","Amount"]'</span> \
+    <span class="op">--db</span> <span class="string">clean.db</span></pre>
+  </div>
+
+  <!-- Python API Recipes -->
+  <h2>Python API Recipes</h2>
+  <p class="section-intro">Using xlfilldown programmatically in scripts and applications.</p>
+
+  <div class="recipe">
+    <span class="tag tag-python">Python</span>
+    <h3>Basic script usage</h3>
+    <p>The simplest way to use xlfilldown in a Python script. Two lines to go from messy .xlsx to clean SQLite.</p>
+    <pre class="code-block"><span class="kw">from</span> xlfilldown.api <span class="kw">import</span> <span class="fn">ingest_excel_to_sqlite</span>
+
+summary = <span class="fn">ingest_excel_to_sqlite</span>(
+    file=<span class="string">"report.xlsx"</span>,
+    sheet=<span class="string">"Sheet1"</span>,
+    header_row=<span class="nb">1</span>,
+    fill_cols=[<span class="string">"Region"</span>, <span class="string">"Country"</span>],
+    db=<span class="string">"output.db"</span>,
+    row_hash=<span class="nb">True</span>,
+    excel_row_numbers=<span class="nb">True</span>,
+    if_exists=<span class="string">"replace"</span>,
+)
+
+<span class="nb">print</span>(<span class="string">f"Ingested </span>{summary[<span class="string">'rows_ingested'</span>]}<span class="string"> rows into </span>{summary[<span class="string">'table'</span>]}<span class="string">"</span>)
+<span class="nb">print</span>(<span class="string">f"Columns: </span>{summary[<span class="string">'columns'</span>]}<span class="string">"</span>)</pre>
+  </div>
+
+  <div class="recipe">
+    <span class="tag tag-python">Python</span>
+    <h3>Excel-to-Excel transformation</h3>
+    <p>Read a messy .xlsx, fill it down, and write a clean .xlsx. No database involved.</p>
+    <pre class="code-block"><span class="kw">from</span> xlfilldown.api <span class="kw">import</span> <span class="fn">ingest_excel_to_excel</span>
+
+summary = <span class="fn">ingest_excel_to_excel</span>(
+    file=<span class="string">"raw_export.xlsx"</span>,
+    sheet=<span class="string">"Data"</span>,
+    header_row=<span class="nb">1</span>,
+    fill_cols=[<span class="string">"Department"</span>, <span class="string">"Team"</span>, <span class="string">"Role"</span>],
+    fill_mode=<span class="string">"hierarchical"</span>,
+    outfile=<span class="string">"clean_export.xlsx"</span>,
+    outsheet=<span class="string">"Filled"</span>,
+    drop_blank_rows=<span class="nb">True</span>,
+    if_exists=<span class="string">"replace"</span>,
+)
+
+<span class="nb">print</span>(<span class="string">f"Wrote </span>{summary[<span class="string">'rows_written'</span>]}<span class="string"> rows"</span>)</pre>
+  </div>
+
+  <div class="recipe">
+    <span class="tag tag-python">Python</span>
+    <h3>Process multiple sheets from one workbook</h3>
+    <p>Loop through several sheets and load each into its own SQLite table.</p>
+    <pre class="code-block"><span class="kw">from</span> xlfilldown.api <span class="kw">import</span> <span class="fn">ingest_excel_to_sqlite</span>
+
+sheets = [
+    (<span class="string">"North America"</span>, [<span class="string">"Country"</span>, <span class="string">"State"</span>]),
+    (<span class="string">"EMEA"</span>, [<span class="string">"Country"</span>, <span class="string">"City"</span>]),
+    (<span class="string">"APAC"</span>, [<span class="string">"Country"</span>, <span class="string">"Region"</span>]),
+]
+
+<span class="kw">for</span> sheet_name, cols <span class="kw">in</span> sheets:
+    summary = <span class="fn">ingest_excel_to_sqlite</span>(
+        file=<span class="string">"global_sales.xlsx"</span>,
+        sheet=sheet_name,
+        header_row=<span class="nb">1</span>,
+        fill_cols=cols,
+        db=<span class="string">"sales.db"</span>,
+        row_hash=<span class="nb">True</span>,
+        if_exists=<span class="string">"replace"</span>,
+    )
+    <span class="nb">print</span>(<span class="string">f"</span>{sheet_name}<span class="string">: </span>{summary[<span class="string">'rows_ingested'</span>]}<span class="string"> rows"</span>)</pre>
+  </div>
+
+  <div class="recipe">
+    <span class="tag tag-python">Python</span>
+    <h3>Using column letters in the API</h3>
+    <p>When you know column positions but not header names (common with inconsistent exports), use <code class="inline">fill_cols_letters</code>.</p>
+    <pre class="code-block"><span class="kw">from</span> xlfilldown.api <span class="kw">import</span> <span class="fn">ingest_excel_to_sqlite</span>
+
+summary = <span class="fn">ingest_excel_to_sqlite</span>(
+    file=<span class="string">"messy_export.xlsx"</span>,
+    sheet=<span class="string">"Sheet1"</span>,
+    header_row=<span class="nb">2</span>,                   <span class="comment"># Headers on row 2</span>
+    fill_cols_letters=[<span class="string">"A"</span>, <span class="string">"B"</span>, <span class="string">"C"</span>],  <span class="comment"># First three columns</span>
+    db=<span class="string">"output.db"</span>,
+    if_exists=<span class="string">"replace"</span>,
+)</pre>
+  </div>
+
+  <!-- Integration Patterns -->
+  <h2>Integration Patterns</h2>
+  <p class="section-intro">Embed xlfilldown into web apps, pipelines, and automation workflows.</p>
+
+  <div class="recipe">
+    <span class="tag tag-integration">Flask</span>
+    <h3>Flask upload endpoint</h3>
+    <p>Accept an .xlsx upload, process it with xlfilldown, and return a summary. Users upload via a form or API call.</p>
+    <pre class="code-block"><span class="kw">import</span> os
+<span class="kw">import</span> tempfile
+<span class="kw">from</span> flask <span class="kw">import</span> Flask, request, jsonify
+<span class="kw">from</span> xlfilldown.api <span class="kw">import</span> <span class="fn">ingest_excel_to_sqlite</span>
+
+app = <span class="fn">Flask</span>(__name__)
+
+<span class="op">@</span>app.<span class="fn">route</span>(<span class="string">"/ingest"</span>, methods=[<span class="string">"POST"</span>])
+<span class="kw">def</span> <span class="fn">ingest</span>():
+    uploaded = request.files[<span class="string">"file"</span>]
+    sheet = request.form.get(<span class="string">"sheet"</span>, <span class="string">"Sheet1"</span>)
+    fill_cols = request.form.getlist(<span class="string">"fill_cols"</span>)
+
+    <span class="kw">with</span> tempfile.<span class="fn">TemporaryDirectory</span>() <span class="kw">as</span> tmp:
+        inpath = os.path.<span class="fn">join</span>(tmp, <span class="string">"upload.xlsx"</span>)
+        dbpath = os.path.<span class="fn">join</span>(tmp, <span class="string">"result.db"</span>)
+        uploaded.<span class="fn">save</span>(inpath)
+
+        summary = <span class="fn">ingest_excel_to_sqlite</span>(
+            file=inpath,
+            sheet=sheet,
+            header_row=<span class="nb">1</span>,
+            fill_cols=fill_cols,
+            db=dbpath,
+            row_hash=<span class="nb">True</span>,
+            excel_row_numbers=<span class="nb">True</span>,
+            if_exists=<span class="string">"replace"</span>,
+        )
+
+    <span class="kw">return</span> <span class="fn">jsonify</span>(summary)</pre>
+  </div>
+
+  <div class="recipe">
+    <span class="tag tag-integration">FastAPI</span>
+    <h3>FastAPI upload endpoint</h3>
+    <p>Same idea with FastAPI and async file handling.</p>
+    <pre class="code-block"><span class="kw">import</span> tempfile
+<span class="kw">from</span> pathlib <span class="kw">import</span> Path
+<span class="kw">from</span> fastapi <span class="kw">import</span> FastAPI, UploadFile, Form
+<span class="kw">from</span> xlfilldown.api <span class="kw">import</span> <span class="fn">ingest_excel_to_sqlite</span>
+
+app = <span class="fn">FastAPI</span>()
+
+<span class="op">@</span>app.<span class="fn">post</span>(<span class="string">"/ingest"</span>)
+<span class="kw">async def</span> <span class="fn">ingest</span>(
+    file: UploadFile,
+    sheet: <span class="nb">str</span> = <span class="fn">Form</span>(<span class="string">"Sheet1"</span>),
+    fill_cols: <span class="nb">str</span> = <span class="fn">Form</span>(<span class="string">'["Region","Country"]'</span>),
+):
+    <span class="kw">import</span> json
+    cols = json.<span class="fn">loads</span>(fill_cols)
+
+    <span class="kw">with</span> tempfile.<span class="fn">NamedTemporaryFile</span>(suffix=<span class="string">".xlsx"</span>, delete=<span class="nb">False</span>) <span class="kw">as</span> tmp:
+        tmp.<span class="fn">write</span>(<span class="kw">await</span> file.<span class="fn">read</span>())
+        tmp_path = tmp.name
+
+    db_path = tmp_path.<span class="fn">replace</span>(<span class="string">".xlsx"</span>, <span class="string">".db"</span>)
+    summary = <span class="fn">ingest_excel_to_sqlite</span>(
+        file=tmp_path,
+        sheet=sheet,
+        header_row=<span class="nb">1</span>,
+        fill_cols=cols,
+        db=db_path,
+        row_hash=<span class="nb">True</span>,
+        if_exists=<span class="string">"replace"</span>,
+    )
+
+    Path(tmp_path).<span class="fn">unlink</span>(missing_ok=<span class="nb">True</span>)
+    <span class="kw">return</span> summary</pre>
+  </div>
+
+  <div class="recipe">
+    <span class="tag tag-pipeline">Pipeline</span>
+    <h3>Shell script for cron / CI</h3>
+    <p>A simple shell script that runs in cron or a CI pipeline. Downloads a report, processes it, and logs the result.</p>
+    <pre class="code-block"><span class="comment">#!/bin/bash</span>
+<span class="comment"># /opt/etl/ingest_weekly.sh</span>
+<span class="comment"># Runs every Monday at 6am via cron</span>
+
+<span class="kw">set</span> <span class="op">-euo</span> pipefail
+
+INFILE=<span class="string">"/data/incoming/weekly_report.xlsx"</span>
+DB=<span class="string">"/data/warehouse/reports.db"</span>
+LOG=<span class="string">"/var/log/etl/weekly_ingest.log"</span>
+
+<span class="nb">echo</span> <span class="string">"[$(date -Iseconds)] Starting ingest"</span> >> <span class="string">"$LOG"</span>
+
+xlfilldown db \
+    <span class="op">--infile</span> <span class="string">"$INFILE"</span> \
+    <span class="op">--insheet</span> <span class="string">"Data"</span> \
+    <span class="op">--header-row</span> <span class="nb">1</span> \
+    <span class="op">--fill-cols</span> <span class="string">'["Region","Country","City"]'</span> \
+    <span class="op">--db</span> <span class="string">"$DB"</span> \
+    <span class="op">--table</span> <span class="string">weekly_sales</span> \
+    <span class="op">--row-hash</span> \
+    <span class="op">--excel-row-numbers</span> \
+    <span class="op">--drop-blank-rows</span> \
+    <span class="op">--if-exists</span> <span class="string">replace</span> \
+    >> <span class="string">"$LOG"</span> 2>&amp;1
+
+<span class="nb">echo</span> <span class="string">"[$(date -Iseconds)] Done"</span> >> <span class="string">"$LOG"</span></pre>
+  </div>
+
+  <div class="recipe">
+    <span class="tag tag-pipeline">Pipeline</span>
+    <h3>Docker one-liner</h3>
+    <p>Run xlfilldown in a container without installing anything on the host. Mount your data directory and go.</p>
+    <pre class="code-block"><span class="prompt" style="color:#64748b">$</span> docker run --rm \
+    -v /path/to/data:/data \
+    python:3.12-slim \
+    sh -c <span class="string">"pip install -q xlfilldown &amp;&amp; xlfilldown db \
+      --infile /data/report.xlsx \
+      --insheet Sheet1 \
+      --header-row 1 \
+      --fill-cols '[\"Region\",\"Country\"]' \
+      --db /data/output.db \
+      --row-hash --excel-row-numbers \
+      --if-exists replace"</span></pre>
+  </div>
+
+  <div class="recipe">
+    <span class="tag tag-pipeline">Pipeline</span>
+    <h3>Airflow task</h3>
+    <p>Use xlfilldown as a step in an Airflow DAG with the BashOperator or PythonOperator.</p>
+    <pre class="code-block"><span class="kw">from</span> airflow.decorators <span class="kw">import</span> task
+
+<span class="op">@</span><span class="fn">task</span>()
+<span class="kw">def</span> <span class="fn">ingest_sales_report</span>(infile: <span class="nb">str</span>, db: <span class="nb">str</span>):
+    <span class="kw">from</span> xlfilldown.api <span class="kw">import</span> <span class="fn">ingest_excel_to_sqlite</span>
+
+    summary = <span class="fn">ingest_excel_to_sqlite</span>(
+        file=infile,
+        sheet=<span class="string">"Sheet1"</span>,
+        header_row=<span class="nb">1</span>,
+        fill_cols=[<span class="string">"Region"</span>, <span class="string">"Country"</span>],
+        db=db,
+        row_hash=<span class="nb">True</span>,
+        excel_row_numbers=<span class="nb">True</span>,
+        drop_blank_rows=<span class="nb">True</span>,
+        if_exists=<span class="string">"replace"</span>,
+    )
+    <span class="kw">return</span> summary</pre>
+  </div>
+
+  <!-- Data Quality -->
+  <h2>Data Quality Patterns</h2>
+  <p class="section-intro">Use audit columns and hashing for validation and debugging.</p>
+
+  <div class="recipe">
+    <span class="tag tag-quality">Quality</span>
+    <h3>Deduplication with row hashes</h3>
+    <p>After ingesting with <code class="inline">--row-hash</code>, query for duplicate rows. Identical content produces identical hashes.</p>
+    <pre class="code-block"><span class="comment">-- Find duplicate rows</span>
+<span class="kw">SELECT</span> row_hash, <span class="fn">COUNT</span>(*) <span class="kw">AS</span> cnt
+<span class="kw">FROM</span> Sheet1
+<span class="kw">GROUP BY</span> row_hash
+<span class="kw">HAVING</span> cnt > <span class="nb">1</span>
+<span class="kw">ORDER BY</span> cnt <span class="kw">DESC</span>;
+
+<span class="comment">-- Keep only the first occurrence</span>
+<span class="kw">DELETE FROM</span> Sheet1
+<span class="kw">WHERE</span> rowid <span class="kw">NOT IN</span> (
+    <span class="kw">SELECT</span> <span class="fn">MIN</span>(rowid) <span class="kw">FROM</span> Sheet1 <span class="kw">GROUP BY</span> row_hash
+);</pre>
+  </div>
+
+  <div class="recipe">
+    <span class="tag tag-quality">Quality</span>
+    <h3>Trace back to the source spreadsheet</h3>
+    <p>With <code class="inline">--excel-row-numbers</code>, every record carries its original .xlsx row number. When a downstream user reports a problem, you can pinpoint the exact source row.</p>
+    <pre class="code-block"><span class="comment">-- "This revenue figure looks wrong" - find the source row</span>
+<span class="kw">SELECT</span> excel_row, Region, Country, City, Product, Revenue
+<span class="kw">FROM</span> Sheet1
+<span class="kw">WHERE</span> Revenue = <span class="string">'99999'</span>;
+
+<span class="comment">-- Result: excel_row = 47</span>
+<span class="comment">-- Open sales_report.xlsx, go to row 47, verify the value</span></pre>
+  </div>
+
+  <div class="recipe">
+    <span class="tag tag-quality">Quality</span>
+    <h3>Compare raw vs filled data</h3>
+    <p>Ingest twice - once raw, once filled - and compare. Useful for validating that the fill logic matches your expectations.</p>
+    <pre class="code-block"><span class="kw">from</span> xlfilldown.api <span class="kw">import</span> <span class="fn">ingest_excel_to_sqlite</span>
+
+<span class="comment"># Raw ingest</span>
+<span class="fn">ingest_excel_to_sqlite</span>(
+    file=<span class="string">"data.xlsx"</span>, sheet=<span class="string">"Sheet1"</span>, header_row=<span class="nb">1</span>,
+    ingest_mode=<span class="string">"raw"</span>,
+    db=<span class="string">"compare.db"</span>, table=<span class="string">"raw"</span>,
+    excel_row_numbers=<span class="nb">True</span>, if_exists=<span class="string">"replace"</span>,
+)
+
+<span class="comment"># Filled ingest</span>
+<span class="fn">ingest_excel_to_sqlite</span>(
+    file=<span class="string">"data.xlsx"</span>, sheet=<span class="string">"Sheet1"</span>, header_row=<span class="nb">1</span>,
+    fill_cols=[<span class="string">"Region"</span>, <span class="string">"Country"</span>],
+    db=<span class="string">"compare.db"</span>, table=<span class="string">"filled"</span>,
+    excel_row_numbers=<span class="nb">True</span>, if_exists=<span class="string">"replace"</span>,
+)
+
+<span class="comment"># Now query to see what changed</span></pre>
+    <pre class="code-block"><span class="comment">-- Find rows where fill-down changed a value</span>
+<span class="kw">SELECT</span>
+    r.excel_row,
+    r.Region <span class="kw">AS</span> raw_region,
+    f.Region <span class="kw">AS</span> filled_region,
+    r.Country <span class="kw">AS</span> raw_country,
+    f.Country <span class="kw">AS</span> filled_country
+<span class="kw">FROM</span> raw r
+<span class="kw">JOIN</span> filled f <span class="kw">ON</span> r.excel_row = f.excel_row
+<span class="kw">WHERE</span> r.Region != f.Region <span class="kw">OR</span> r.Country != f.Country
+   <span class="kw">OR</span> (r.Region <span class="kw">IS NULL AND</span> f.Region <span class="kw">IS NOT NULL</span>)
+   <span class="kw">OR</span> (r.Country <span class="kw">IS NULL AND</span> f.Country <span class="kw">IS NOT NULL</span>);</pre>
+  </div>
+
+  <!-- Design Patterns -->
+  <h2>Design Patterns</h2>
+  <p class="section-intro">Architectural approaches for common scenarios.</p>
+
+  <div class="recipe">
+    <span class="tag tag-pattern">Pattern</span>
+    <h3>Hierarchical vs independent - choosing the right mode</h3>
+    <p>Use <strong>hierarchical</strong> when columns have a parent-child relationship (Region &gt; Country &gt; City). A change in a parent column should invalidate stale child values.</p>
+    <p>Use <strong>independent</strong> when columns are unrelated dimensions that happen to share blank patterns. For example, "Salesperson" and "Product Line" might both be sparse but don't depend on each other.</p>
+    <div class="note">
+      <p><strong>Rule of thumb:</strong> If you would use a tree diagram to describe the relationship between columns, use hierarchical. If the columns are flat attributes, use independent.</p>
+    </div>
+  </div>
+
+  <div class="recipe">
+    <span class="tag tag-pattern">Pattern</span>
+    <h3>Header row is not row 1</h3>
+    <p>Many .xlsx exports have title rows, blank rows, or metadata above the actual headers. Use <code class="inline">--header-row</code> to point at the correct row. Everything above that row is ignored.</p>
+    <pre class="code-block"><span class="comment"># Headers are on row 3 (rows 1-2 are title/metadata)</span>
+<span class="prompt" style="color:#64748b">$</span> xlfilldown db \
+    <span class="op">--infile</span> <span class="string">finance_report.xlsx</span> \
+    <span class="op">--insheet</span> <span class="string">"P&amp;L"</span> \
+    <span class="op">--header-row</span> <span class="nb">3</span> \
+    <span class="op">--fill-cols</span> <span class="string">'["Account Group","Account"]'</span> \
+    <span class="op">--db</span> <span class="string">finance.db</span></pre>
+  </div>
+
+  <div class="recipe">
+    <span class="tag tag-pattern">Pattern</span>
+    <h3>Batch size tuning for large files</h3>
+    <p>The default batch size of 1000 rows works well for most files. For very large sheets (100K+ rows), a larger batch size reduces SQLite transaction overhead.</p>
+    <pre class="code-block"><span class="prompt" style="color:#64748b">$</span> xlfilldown db \
+    <span class="op">--infile</span> <span class="string">huge_export.xlsx</span> \
+    <span class="op">--insheet</span> <span class="string">"Data"</span> \
+    <span class="op">--header-row</span> <span class="nb">1</span> \
+    <span class="op">--fill-cols</span> <span class="string">'["Category"]'</span> \
+    <span class="op">--db</span> <span class="string">warehouse.db</span> \
+    <span class="op">--batch-size</span> <span class="nb">5000</span></pre>
+  </div>
+
+  <div class="recipe">
+    <span class="tag tag-pattern">Pattern</span>
+    <h3>Combining require-non-null with letters</h3>
+    <p>Mix header-name and column-letter approaches for filtering. Both are merged and de-duplicated internally.</p>
+    <pre class="code-block"><span class="prompt" style="color:#64748b">$</span> xlfilldown db \
+    <span class="op">--infile</span> <span class="string">data.xlsx</span> \
+    <span class="op">--insheet</span> <span class="string">"Sheet1"</span> \
+    <span class="op">--header-row</span> <span class="nb">1</span> \
+    <span class="op">--fill-cols-letters</span> <span class="nb">A B C</span> \
+    <span class="op">--require-non-null</span> <span class="string">'["Amount"]'</span> \
+    <span class="op">--require-non-null-letters</span> <span class="nb">A</span> \
+    <span class="op">--db</span> <span class="string">filtered.db</span></pre>
+  </div>
+
+  <!-- Quick Reference -->
+  <h2>Quick Reference</h2>
+  <p class="section-intro">At-a-glance summary of the most common options.</p>
+
+  <table class="ref-table">
+    <thead><tr><th>Task</th><th>Key Options</th></tr></thead>
+    <tbody>
+      <tr><td>Fill by header names</td><td><code class="inline">--fill-cols '["Col1","Col2"]'</code></td></tr>
+      <tr><td>Fill by column letters</td><td><code class="inline">--fill-cols-letters A B C</code></td></tr>
+      <tr><td>Hierarchical fill (default)</td><td><code class="inline">--fill-mode hierarchical</code></td></tr>
+      <tr><td>Independent fill</td><td><code class="inline">--fill-mode independent</code></td></tr>
+      <tr><td>Skip fill-down</td><td><code class="inline">--ingest-mode raw</code></td></tr>
+      <tr><td>Add row hashes</td><td><code class="inline">--row-hash</code></td></tr>
+      <tr><td>Add source row numbers</td><td><code class="inline">--excel-row-numbers</code></td></tr>
+      <tr><td>Drop spacer rows</td><td><code class="inline">--drop-blank-rows</code></td></tr>
+      <tr><td>Require non-null columns</td><td><code class="inline">--require-non-null '["Col"]'</code></td></tr>
+      <tr><td>Overwrite on re-run</td><td><code class="inline">--if-exists replace</code></td></tr>
+      <tr><td>Append to existing</td><td><code class="inline">--if-exists append</code></td></tr>
+      <tr><td>Custom table name</td><td><code class="inline">--table my_table</code></td></tr>
+      <tr><td>Tune batch size</td><td><code class="inline">--batch-size 5000</code></td></tr>
+    </tbody>
+  </table>
+
+  <!-- API Quick Reference -->
+  <h2>API Reference</h2>
+  <p class="section-intro">Key functions and their return values.</p>
+
+  <table class="ref-table">
+    <thead><tr><th>Function</th><th>Output</th><th>Return Keys</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><code class="inline">ingest_excel_to_sqlite()</code></td>
+        <td>SQLite database</td>
+        <td><code class="inline">table</code>, <code class="inline">columns</code>, <code class="inline">rows_ingested</code>, <code class="inline">row_hash</code>, <code class="inline">excel_row_numbers</code></td>
+      </tr>
+      <tr>
+        <td><code class="inline">ingest_excel_to_excel()</code></td>
+        <td>.xlsx file</td>
+        <td><code class="inline">workbook</code>, <code class="inline">sheet</code>, <code class="inline">columns</code>, <code class="inline">rows_written</code>, <code class="inline">row_hash</code>, <code class="inline">excel_row_numbers</code></td>
+      </tr>
+      <tr>
+        <td><code class="inline">normalize_headers()</code></td>
+        <td>list[str]</td>
+        <td>Trimmed, normalized header strings</td>
+      </tr>
+      <tr>
+        <td><code class="inline">canon_list()</code></td>
+        <td>str</td>
+        <td>JSON-format canonical string</td>
+      </tr>
+      <tr>
+        <td><code class="inline">sha256_hex()</code></td>
+        <td>str</td>
+        <td>64-char hex digest</td>
+      </tr>
+      <tr>
+        <td><code class="inline">qident()</code></td>
+        <td>str</td>
+        <td>Safely quoted SQLite identifier</td>
+      </tr>
+    </tbody>
+  </table>
+
+</div>
+
+<footer class="site-footer">
+  <div class="footer-inner">
+    <div class="footer-brand">
+      <h3>xlf<span>ill</span>down</h3>
+      <p>A Python library for filling down values in .xlsx spreadsheets (OOXML).</p>
+    </div>
+    <div class="footer-links">
+      <h4>Documentation</h4>
+      <a href="index.html">Home</a>
+      <a href="reference.html">Reference Guide</a>
+      <a href="best_practices.html">Best Practices</a>
+    </div>
+    <div class="footer-links">
+      <h4>Project</h4>
+      <a href="https://github.com/RexBytes/xlfilldown">GitHub</a>
+      <a href="https://pypi.org/project/xlfilldown/">PyPI</a>
+      <a href="https://github.com/RexBytes/xlfilldown/releases">Changelog</a>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2025 RexBytes. MIT License.</span>
+    <p class="disclaimer">Not affiliated with or endorsed by Microsoft Corporation. "Excel" and ".xlsx" are trademarks or file formats associated with Microsoft. xlfilldown is an independent open-source Python package that reads and writes OOXML (.xlsx) files via the openpyxl library.</p>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,1171 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>xlfilldown - Forward-fill .xlsx spreadsheets into SQLite or Excel</title>
+<meta name="description" content="A Python library for filling down values in .xlsx spreadsheets (OOXML). Stream into SQLite or a new Excel sheet with forward-fill, row hashing, and audit columns.">
+<meta property="og:title" content="xlfilldown - Forward-fill .xlsx spreadsheets">
+<meta property="og:description" content="A Python library for filling down values in .xlsx spreadsheets (OOXML). Stream into SQLite or Excel with forward-fill padding, preserved row numbers, and stable SHA-256 row hashes.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://xlfilldown.net">
+<meta property="og:image" content="https://xlfilldown.net/og-image.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #1a1a2e;
+  line-height: 1.6;
+  background: #fff;
+}
+
+a { color: #2563eb; text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+code, pre {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Consolas', monospace;
+}
+
+/* Header */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: linear-gradient(135deg, #1a1a2e, #16213e, #0f3460);
+  padding: 0 24px;
+  box-shadow: 0 2px 12px rgba(0,0,0,0.3);
+}
+.header-inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 60px;
+}
+.logo {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #fff;
+  letter-spacing: -0.5px;
+}
+.logo span { color: #60a5fa; }
+nav { display: flex; gap: 24px; align-items: center; }
+nav a {
+  color: #cbd5e1;
+  font-size: 0.9rem;
+  font-weight: 500;
+  transition: color 0.2s;
+  text-decoration: none;
+}
+nav a:hover, nav a.active { color: #fff; text-decoration: none; }
+
+/* Hero */
+.hero {
+  background: linear-gradient(135deg, #1a1a2e, #16213e, #0f3460);
+  padding: 80px 24px 72px;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+.hero::before {
+  content: '';
+  position: absolute;
+  top: -50%;
+  left: -50%;
+  width: 200%;
+  height: 200%;
+  background: radial-gradient(circle at 30% 50%, rgba(37, 99, 235, 0.08) 0%, transparent 50%),
+              radial-gradient(circle at 70% 80%, rgba(96, 165, 250, 0.06) 0%, transparent 40%);
+  pointer-events: none;
+}
+.hero-content { position: relative; z-index: 1; max-width: 800px; margin: 0 auto; }
+.hero h1 {
+  font-size: 3rem;
+  font-weight: 700;
+  color: #fff;
+  margin-bottom: 12px;
+  letter-spacing: -1px;
+}
+.hero .subtitle {
+  font-size: 1.2rem;
+  color: #94a3b8;
+  margin-bottom: 32px;
+  max-width: 640px;
+  margin-left: auto;
+  margin-right: auto;
+  line-height: 1.7;
+}
+.install-box {
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.15);
+  border-radius: 10px;
+  padding: 16px 24px;
+  display: inline-block;
+  margin-bottom: 28px;
+}
+.install-box code {
+  color: #e2e8f0;
+  font-size: 1.05rem;
+}
+.install-box .prompt { color: #64748b; }
+.cta-row {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+.btn-primary {
+  background: #2563eb;
+  color: #fff;
+  padding: 12px 28px;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: background 0.2s, transform 0.15s;
+  display: inline-block;
+}
+.btn-primary:hover { background: #1d4ed8; transform: translateY(-1px); text-decoration: none; }
+.btn-outline {
+  border: 1px solid rgba(255,255,255,0.25);
+  color: #cbd5e1;
+  padding: 12px 28px;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: border-color 0.2s, color 0.2s;
+  display: inline-block;
+}
+.btn-outline:hover { border-color: #fff; color: #fff; text-decoration: none; }
+
+/* Sections */
+.section { padding: 72px 24px; }
+.section-alt { background: #f8fafc; }
+.section-title {
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: #1e3a5f;
+  text-align: center;
+  margin-bottom: 12px;
+}
+.section-subtitle {
+  text-align: center;
+  color: #64748b;
+  max-width: 600px;
+  margin: 0 auto 48px;
+  font-size: 1rem;
+}
+
+/* Problem / Pain section */
+.pain-grid {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 24px;
+}
+.pain-card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 28px;
+  transition: box-shadow 0.2s, transform 0.15s;
+}
+.pain-card:hover { box-shadow: 0 8px 24px rgba(0,0,0,0.08); transform: translateY(-2px); }
+.pain-card .icon { font-size: 1.6rem; margin-bottom: 12px; display: block; }
+.pain-card h3 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1e3a5f;
+  margin-bottom: 8px;
+}
+.pain-card p { color: #475569; font-size: 0.93rem; line-height: 1.6; }
+
+/* Key Idea */
+.key-idea {
+  background: #f0f9ff;
+  border-top: 3px solid #2563eb;
+  padding: 56px 24px;
+}
+.key-idea-inner {
+  max-width: 800px;
+  margin: 0 auto;
+  text-align: center;
+}
+.key-idea h2 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #1e3a5f;
+  margin-bottom: 16px;
+}
+.key-idea p {
+  color: #475569;
+  margin-bottom: 24px;
+  font-size: 1rem;
+}
+
+/* Code blocks */
+pre.code-block {
+  background: #1e293b;
+  color: #e2e8f0;
+  border-radius: 10px;
+  padding: 20px 24px;
+  overflow-x: auto;
+  font-size: 0.88rem;
+  line-height: 1.7;
+  text-align: left;
+}
+code.inline {
+  background: #e2e8f0;
+  color: #1e293b;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.88em;
+}
+.kw, .keyword { color: #93c5fd; }
+.fn { color: #fbbf24; }
+.st, .string { color: #86efac; }
+.cm, .comment { color: #64748b; }
+.op { color: #f472b6; }
+.nb { color: #c4b5fd; }
+
+/* Animated Demo */
+.demo-section {
+  padding: 72px 24px;
+  background: #f8fafc;
+}
+.demo-container {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+.demo-flow {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 12px;
+  align-items: start;
+  margin-bottom: 48px;
+}
+.demo-arrow {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding-top: 80px;
+  color: #2563eb;
+  font-weight: 600;
+  font-size: 0.82rem;
+  gap: 6px;
+}
+.demo-arrow svg { width: 32px; height: 32px; }
+.demo-panel {
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+}
+.demo-panel-header {
+  background: #f3f4f6;
+  border-bottom: 1px solid #d1d5db;
+  padding: 8px 14px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.78rem;
+  color: #6b7280;
+  font-weight: 500;
+}
+.demo-panel-header .dots {
+  display: flex; gap: 4px;
+}
+.demo-panel-header .dot {
+  width: 8px; height: 8px; border-radius: 50%;
+}
+.dot-r { background: #ef4444; }
+.dot-y { background: #f59e0b; }
+.dot-g { background: #22c55e; }
+
+/* Spreadsheet table */
+.sheet-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8rem;
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', monospace;
+}
+.sheet-table th {
+  background: #e5e7eb;
+  color: #374151;
+  font-weight: 600;
+  padding: 6px 10px;
+  border: 1px solid #d1d5db;
+  text-align: left;
+  font-size: 0.75rem;
+}
+.sheet-table .row-num {
+  background: #f3f4f6;
+  color: #9ca3af;
+  text-align: center;
+  width: 32px;
+  font-size: 0.72rem;
+  border: 1px solid #d1d5db;
+  padding: 6px 4px;
+}
+.sheet-table td {
+  padding: 6px 10px;
+  border: 1px solid #e5e7eb;
+  color: #374151;
+  height: 28px;
+}
+.sheet-table tr:nth-child(even) td:not(.row-num) { background: #fafafa; }
+.cell-empty { color: #d1d5db; }
+.cell-filled {
+  background: #dbeafe !important;
+  color: #1e40af !important;
+  font-weight: 500;
+  position: relative;
+}
+.cell-filled-anim {
+  opacity: 0;
+  transition: opacity 0.4s ease, background 0.4s ease;
+}
+.cell-filled-anim.visible {
+  opacity: 1;
+}
+
+/* DB Viewer */
+.db-viewer {
+  background: #fff;
+  border: 1px solid #c6c6c6;
+  border-radius: 4px;
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+}
+.db-toolbar {
+  background: #f0f0f0;
+  border-bottom: 1px solid #c6c6c6;
+  padding: 4px 8px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.72rem;
+  color: #555;
+}
+.db-toolbar-btn {
+  background: #e8e8e8;
+  border: 1px solid #bbb;
+  border-radius: 3px;
+  padding: 2px 8px;
+  font-size: 0.68rem;
+  color: #444;
+  font-family: 'Inter', sans-serif;
+}
+.db-toolbar-sep { width: 1px; height: 16px; background: #c6c6c6; }
+.db-status-bar {
+  background: #f0f0f0;
+  border-top: 1px solid #c6c6c6;
+  padding: 3px 8px;
+  font-size: 0.68rem;
+  color: #888;
+}
+.db-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.76rem;
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', monospace;
+}
+.db-table th {
+  background: #e8e8e8;
+  color: #333;
+  font-weight: 600;
+  padding: 5px 10px;
+  border: 1px solid #c6c6c6;
+  text-align: left;
+  font-size: 0.72rem;
+}
+.db-table td {
+  padding: 4px 10px;
+  border: 1px solid #ddd;
+  color: #444;
+}
+.db-table tr:nth-child(even) td { background: #f7f7f7; }
+.db-table .col-hash { color: #888; font-size: 0.68rem; max-width: 120px; overflow: hidden; text-overflow: ellipsis; }
+.db-table .col-rownum { color: #2563eb; font-weight: 500; }
+
+/* Click-along mode */
+.click-along {
+  max-width: 800px;
+  margin: 40px auto 0;
+  text-align: center;
+}
+.click-along h3 {
+  font-size: 1.15rem;
+  color: #1e3a5f;
+  margin-bottom: 8px;
+  font-weight: 600;
+}
+.click-along p {
+  color: #64748b;
+  font-size: 0.9rem;
+  margin-bottom: 16px;
+}
+.step-controls {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+.step-btn {
+  background: #2563eb;
+  color: #fff;
+  border: none;
+  padding: 10px 22px;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.88rem;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.15s;
+  font-family: 'Inter', sans-serif;
+}
+.step-btn:hover { background: #1d4ed8; transform: translateY(-1px); }
+.step-btn:disabled { background: #94a3b8; cursor: not-allowed; transform: none; }
+.step-btn-outline {
+  background: transparent;
+  color: #2563eb;
+  border: 2px solid #2563eb;
+  padding: 10px 22px;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.88rem;
+  cursor: pointer;
+  transition: background 0.2s;
+  font-family: 'Inter', sans-serif;
+}
+.step-btn-outline:hover { background: #eff6ff; }
+.step-indicator {
+  color: #64748b;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+/* Who benefits */
+.audience-grid {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 24px;
+}
+.audience-card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 28px;
+  transition: box-shadow 0.2s;
+}
+.audience-card:hover { box-shadow: 0 8px 24px rgba(0,0,0,0.08); }
+.audience-card .label {
+  display: inline-block;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 3px 10px;
+  border-radius: 20px;
+  margin-bottom: 12px;
+}
+.label-engineer { background: #dbeafe; color: #1e40af; }
+.label-analyst { background: #fef3c7; color: #92400e; }
+.label-pipeline { background: #dcfce7; color: #166534; }
+.audience-card h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #1e3a5f;
+  margin-bottom: 8px;
+}
+.audience-card p { color: #475569; font-size: 0.9rem; }
+
+/* Features grid */
+.features-grid {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 24px;
+}
+.feature-card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 28px;
+  transition: box-shadow 0.2s, transform 0.15s;
+}
+.feature-card:hover { box-shadow: 0 8px 24px rgba(0,0,0,0.08); transform: translateY(-2px); }
+.feature-card h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #1e3a5f;
+  margin-bottom: 8px;
+}
+.feature-card p { color: #475569; font-size: 0.9rem; }
+.feature-icon {
+  width: 40px;
+  height: 40px;
+  background: #eff6ff;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 16px;
+  font-size: 1.2rem;
+}
+
+/* Quickstart */
+.quickstart {
+  max-width: 800px;
+  margin: 0 auto;
+}
+.step {
+  display: flex;
+  gap: 20px;
+  margin-bottom: 32px;
+  align-items: flex-start;
+}
+.step-num {
+  width: 36px;
+  height: 36px;
+  min-width: 36px;
+  background: #2563eb;
+  color: #fff;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.95rem;
+  margin-top: 2px;
+}
+.step-content { flex: 1; }
+.step-content h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #1e3a5f;
+  margin-bottom: 8px;
+}
+.step-content p { color: #475569; font-size: 0.9rem; margin-bottom: 12px; }
+
+/* Compat */
+.compat-grid {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 20px;
+}
+.compat-card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 24px;
+  text-align: center;
+}
+.compat-card .version {
+  color: #2563eb;
+  font-size: 1.3em;
+  font-weight: 700;
+  display: block;
+  margin-bottom: 4px;
+}
+.compat-card .label {
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+/* Footer */
+.site-footer {
+  background: linear-gradient(135deg, #1a1a2e, #16213e, #0f3460);
+  padding: 48px 24px 32px;
+  color: #94a3b8;
+  font-size: 0.85rem;
+}
+.footer-inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  gap: 40px;
+}
+.footer-brand h3 { color: #fff; font-size: 1.1rem; margin-bottom: 8px; }
+.footer-brand h3 span { color: #60a5fa; }
+.footer-links h4 { color: #cbd5e1; font-size: 0.9rem; margin-bottom: 12px; }
+.footer-links a { color: #94a3b8; display: block; margin-bottom: 6px; font-size: 0.85rem; }
+.footer-links a:hover { color: #fff; text-decoration: none; }
+.footer-bottom {
+  max-width: 1100px;
+  margin: 32px auto 0;
+  padding-top: 24px;
+  border-top: 1px solid rgba(255,255,255,0.1);
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+.disclaimer {
+  color: #64748b;
+  font-size: 0.78rem;
+  max-width: 600px;
+  line-height: 1.5;
+}
+
+/* Mobile nav toggle */
+.nav-toggle { display: none; background: none; border: none; cursor: pointer; padding: 4px; }
+.nav-toggle span { display: block; width: 22px; height: 2px; background: #cbd5e1; margin: 5px 0; transition: 0.3s; }
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero h1 { font-size: 2rem; }
+  .hero .subtitle { font-size: 1rem; }
+  .features-grid, .pain-grid, .audience-grid { grid-template-columns: 1fr; }
+  .demo-flow { grid-template-columns: 1fr; }
+  .demo-arrow { flex-direction: row; padding-top: 0; padding: 8px 0; }
+  .demo-arrow svg { transform: rotate(90deg); }
+  .footer-inner { grid-template-columns: 1fr; gap: 24px; }
+  .footer-bottom { flex-direction: column; text-align: center; }
+  .header-inner { flex-wrap: wrap; }
+  nav { gap: 12px; flex-wrap: wrap; justify-content: center; }
+  .compat-grid { grid-template-columns: repeat(2, 1fr); }
+  .nav-toggle { display: block; }
+  nav.nav-closed { display: none; }
+  nav.nav-open { display: flex; width: 100%; padding: 12px 0; }
+  .section { padding: 48px 16px; }
+}
+</style>
+</head>
+<body>
+
+<!-- Header -->
+<header class="site-header">
+  <div class="header-inner">
+    <a href="index.html" class="logo">xlf<span>ill</span>down</a>
+    <button class="nav-toggle" onclick="document.querySelector('nav').classList.toggle('nav-open');document.querySelector('nav').classList.toggle('nav-closed')" aria-label="Toggle navigation">
+      <span></span><span></span><span></span>
+    </button>
+    <nav>
+      <a href="index.html" class="active">Home</a>
+      <a href="reference.html">Reference</a>
+      <a href="best_practices.html">Best Practices</a>
+      <a href="https://github.com/RexBytes/xlfilldown">GitHub</a>
+      <a href="https://pypi.org/project/xlfilldown/">PyPI</a>
+    </nav>
+  </div>
+</header>
+
+<!-- Hero -->
+<section class="hero">
+  <div class="hero-content">
+    <h1>xlfilldown</h1>
+    <p class="subtitle">A Python library for filling down values in .xlsx spreadsheets (OOXML). Stream into SQLite or a new Excel sheet with forward-fill padding, preserved row numbers, and stable SHA-256 row hashes.</p>
+    <div class="install-box">
+      <code><span class="prompt">$</span> pip install xlfilldown</code>
+    </div>
+    <div class="cta-row">
+      <a href="reference.html" class="btn-primary">Read the Docs</a>
+      <a href="https://github.com/RexBytes/xlfilldown" class="btn-outline">View on GitHub</a>
+    </div>
+  </div>
+</section>
+
+<!-- Problem Section -->
+<section class="section">
+  <h2 class="section-title">The Problem</h2>
+  <p class="section-subtitle">Hierarchical .xlsx exports are everywhere - and they are a pain to work with programmatically.</p>
+  <div class="pain-grid">
+    <div class="pain-card">
+      <span class="icon">&#x1F4C9;</span>
+      <h3>Merged and sparse data</h3>
+      <p>Reporting tools export grouped data where "Region" only appears once for a block of rows. Every row below is blank until the next group. You need flat, filled rows for SQL queries, pandas, or dashboards.</p>
+    </div>
+    <div class="pain-card">
+      <span class="icon">&#x1F527;</span>
+      <h3>Manual cleanup is fragile</h3>
+      <p>Opening the file and dragging fill-down by hand works once - but breaks the moment a new export lands. You need something repeatable in a script or data pipeline.</p>
+    </div>
+    <div class="pain-card">
+      <span class="icon">&#x1F504;</span>
+      <h3>Pandas overhead for simple ETL</h3>
+      <p>Pulling in pandas just to forward-fill a few columns and write to SQLite is a heavy dependency. xlfilldown does the job with only openpyxl, streaming rows in constant memory.</p>
+    </div>
+    <div class="pain-card">
+      <span class="icon">&#x1F50D;</span>
+      <h3>No audit trail</h3>
+      <p>When something looks wrong downstream, you need to trace a row back to the original spreadsheet. Without preserved row numbers and stable hashes, debugging is guesswork.</p>
+    </div>
+    <div class="pain-card">
+      <span class="icon">&#x26A0;&#xFE0F;</span>
+      <h3>Hierarchical resets</h3>
+      <p>When "Region" changes, "Country" and "City" should reset - not carry stale values from the previous group. Most simple ffill solutions get this wrong.</p>
+    </div>
+    <div class="pain-card">
+      <span class="icon">&#x1F4E6;</span>
+      <h3>No lightweight CLI tool</h3>
+      <p>You want to run a single command in CI/CD or cron to ingest an .xlsx into SQLite, with fill-down, hashing, and row numbers - without writing a custom script every time.</p>
+    </div>
+  </div>
+</section>
+
+<!-- Interactive Demo -->
+<section class="demo-section" id="demo">
+  <h2 class="section-title">See It in Action</h2>
+  <p class="section-subtitle">Watch xlfilldown transform sparse hierarchical data into clean, filled rows - then load it into a database.</p>
+
+  <div class="demo-container">
+    <!-- Click Along Controls -->
+    <div class="click-along">
+      <h3>Interactive Walkthrough</h3>
+      <p>Step through the fill-down process to see how each stage transforms the data.</p>
+      <div class="step-controls">
+        <button class="step-btn" id="btn-prev" disabled onclick="demoStep(-1)">Previous</button>
+        <span class="step-indicator" id="step-label">Step 1 of 4</span>
+        <button class="step-btn" id="btn-next" onclick="demoStep(1)">Next Step</button>
+        <button class="step-btn-outline" id="btn-auto" onclick="demoAutoPlay()">Auto Play</button>
+      </div>
+    </div>
+
+    <!-- Step 1 & 2: Spreadsheet Before / After -->
+    <div class="demo-flow" id="demo-sheets">
+      <!-- Input Sheet -->
+      <div class="demo-panel" id="panel-input">
+        <div class="demo-panel-header">
+          <div class="dots"><span class="dot dot-r"></span><span class="dot dot-y"></span><span class="dot dot-g"></span></div>
+          sales_report.xlsx - Sheet1
+        </div>
+        <table class="sheet-table" id="sheet-input">
+          <thead>
+            <tr>
+              <th style="width:32px"></th>
+              <th>A</th><th>B</th><th>C</th><th>D</th><th>E</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td class="row-num">1</td><td style="font-weight:600">Region</td><td style="font-weight:600">Country</td><td style="font-weight:600">City</td><td style="font-weight:600">Product</td><td style="font-weight:600">Revenue</td></tr>
+            <tr><td class="row-num">2</td><td>EMEA</td><td>UK</td><td>London</td><td>Widget A</td><td>12500</td></tr>
+            <tr><td class="row-num">3</td><td class="cell-empty"></td><td class="cell-empty"></td><td>Manchester</td><td>Widget B</td><td>8300</td></tr>
+            <tr><td class="row-num">4</td><td class="cell-empty"></td><td>Germany</td><td>Berlin</td><td>Widget A</td><td>15200</td></tr>
+            <tr><td class="row-num">5</td><td class="cell-empty"></td><td class="cell-empty"></td><td>Munich</td><td>Widget C</td><td>9100</td></tr>
+            <tr><td class="row-num">6</td><td>APAC</td><td>Japan</td><td>Tokyo</td><td>Widget B</td><td>22400</td></tr>
+            <tr><td class="row-num">7</td><td class="cell-empty"></td><td class="cell-empty"></td><td>Osaka</td><td>Widget A</td><td>11800</td></tr>
+            <tr><td class="row-num">8</td><td class="cell-empty"></td><td>Australia</td><td>Sydney</td><td>Widget C</td><td>17600</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Arrow -->
+      <div class="demo-arrow" id="arrow1">
+        <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 16h20m0 0l-6-6m6 6l-6 6" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <span>xlfilldown</span>
+      </div>
+
+      <!-- Output Sheet -->
+      <div class="demo-panel" id="panel-output" style="opacity: 0.3;">
+        <div class="demo-panel-header">
+          <div class="dots"><span class="dot dot-r"></span><span class="dot dot-y"></span><span class="dot dot-g"></span></div>
+          sales_filled.xlsx - Processed
+        </div>
+        <table class="sheet-table" id="sheet-output">
+          <thead>
+            <tr>
+              <th style="width:32px"></th>
+              <th>A</th><th>B</th><th>C</th><th>D</th><th>E</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td class="row-num">1</td><td style="font-weight:600">Region</td><td style="font-weight:600">Country</td><td style="font-weight:600">City</td><td style="font-weight:600">Product</td><td style="font-weight:600">Revenue</td></tr>
+            <tr><td class="row-num">2</td><td>EMEA</td><td>UK</td><td>London</td><td>Widget A</td><td>12500</td></tr>
+            <tr><td class="row-num">3</td><td class="cell-filled cell-filled-anim" data-step="2">EMEA</td><td class="cell-filled cell-filled-anim" data-step="2">UK</td><td>Manchester</td><td>Widget B</td><td>8300</td></tr>
+            <tr><td class="row-num">4</td><td class="cell-filled cell-filled-anim" data-step="2">EMEA</td><td>Germany</td><td>Berlin</td><td>Widget A</td><td>15200</td></tr>
+            <tr><td class="row-num">5</td><td class="cell-filled cell-filled-anim" data-step="2">EMEA</td><td class="cell-filled cell-filled-anim" data-step="2">Germany</td><td>Munich</td><td>Widget C</td><td>9100</td></tr>
+            <tr><td class="row-num">6</td><td>APAC</td><td>Japan</td><td>Tokyo</td><td>Widget B</td><td>22400</td></tr>
+            <tr><td class="row-num">7</td><td class="cell-filled cell-filled-anim" data-step="2">APAC</td><td class="cell-filled cell-filled-anim" data-step="2">Japan</td><td>Osaka</td><td>Widget A</td><td>11800</td></tr>
+            <tr><td class="row-num">8</td><td class="cell-filled cell-filled-anim" data-step="2">APAC</td><td>Australia</td><td>Sydney</td><td>Widget C</td><td>17600</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Step 3: Command shown -->
+    <div id="demo-command" style="max-width: 800px; margin: 0 auto 32px; display: none;">
+      <p style="color: #1e3a5f; font-weight: 600; font-size: 0.95rem; margin-bottom: 12px; text-align: center;">The command that does it all:</p>
+      <pre class="code-block"><span class="prompt" style="color:#64748b">$</span> xlfilldown db \
+    <span class="op">--infile</span> <span class="string">sales_report.xlsx</span> \
+    <span class="op">--insheet</span> <span class="string">"Sheet1"</span> \
+    <span class="op">--header-row</span> <span class="nb">1</span> \
+    <span class="op">--fill-cols</span> <span class="string">'["Region","Country"]'</span> \
+    <span class="op">--db</span> <span class="string">sales.db</span> \
+    <span class="op">--row-hash</span> <span class="op">--excel-row-numbers</span></pre>
+    </div>
+
+    <!-- Step 4: Database View -->
+    <div id="demo-db" style="max-width: 960px; margin: 0 auto; display: none;">
+      <p style="color: #1e3a5f; font-weight: 600; font-size: 0.95rem; margin-bottom: 12px; text-align: center;">Result in SQLite:</p>
+      <div class="db-viewer">
+        <div class="db-toolbar">
+          <span class="db-toolbar-btn">Browse Data</span>
+          <span class="db-toolbar-btn" style="background:transparent;border-color:transparent;color:#999">Execute SQL</span>
+          <span class="db-toolbar-sep"></span>
+          <span style="color:#999">Table:</span>
+          <span style="color:#444;font-weight:500">Sheet1</span>
+        </div>
+        <table class="db-table">
+          <thead>
+            <tr><th>row_hash</th><th>excel_row</th><th>Region</th><th>Country</th><th>City</th><th>Product</th><th>Revenue</th></tr>
+          </thead>
+          <tbody>
+            <tr><td class="col-hash">a3f1c8...</td><td class="col-rownum">2</td><td>EMEA</td><td>UK</td><td>London</td><td>Widget A</td><td>12500</td></tr>
+            <tr><td class="col-hash">7b2e91...</td><td class="col-rownum">3</td><td>EMEA</td><td>UK</td><td>Manchester</td><td>Widget B</td><td>8300</td></tr>
+            <tr><td class="col-hash">d4f5a2...</td><td class="col-rownum">4</td><td>EMEA</td><td>Germany</td><td>Berlin</td><td>Widget A</td><td>15200</td></tr>
+            <tr><td class="col-hash">e8c3b7...</td><td class="col-rownum">5</td><td>EMEA</td><td>Germany</td><td>Munich</td><td>Widget C</td><td>9100</td></tr>
+            <tr><td class="col-hash">1a9d4e...</td><td class="col-rownum">6</td><td>APAC</td><td>Japan</td><td>Tokyo</td><td>Widget B</td><td>22400</td></tr>
+            <tr><td class="col-hash">c6f2b8...</td><td class="col-rownum">7</td><td>APAC</td><td>Japan</td><td>Osaka</td><td>Widget A</td><td>11800</td></tr>
+            <tr><td class="col-hash">5e7a13...</td><td class="col-rownum">8</td><td>APAC</td><td>Australia</td><td>Sydney</td><td>Widget C</td><td>17600</td></tr>
+          </tbody>
+        </table>
+        <div class="db-status-bar">7 rows returned | Table: Sheet1 | Database: sales.db</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Key Idea -->
+<section class="key-idea">
+  <div class="key-idea-inner">
+    <h2>One command. Clean data.</h2>
+    <p>xlfilldown reads your .xlsx, forward-fills the sparse columns you specify, and writes to SQLite or a new Excel file. No pandas. No manual steps. Just pipe it into your workflow.</p>
+    <pre class="code-block"><span class="comment"># Python API - two lines to go from messy .xlsx to clean SQLite</span>
+<span class="kw">from</span> xlfilldown.api <span class="kw">import</span> <span class="fn">ingest_excel_to_sqlite</span>
+
+summary = <span class="fn">ingest_excel_to_sqlite</span>(
+    file=<span class="string">"report.xlsx"</span>,
+    sheet=<span class="string">"Sheet1"</span>,
+    header_row=<span class="nb">1</span>,
+    fill_cols=[<span class="string">"Region"</span>, <span class="string">"Country"</span>],
+    db=<span class="string">"output.db"</span>,
+    row_hash=<span class="nb">True</span>,
+    excel_row_numbers=<span class="nb">True</span>,
+)
+<span class="nb">print</span>(<span class="string">f"Ingested </span>{summary[<span class="string">'rows_ingested'</span>]}<span class="string"> rows"</span>)</pre>
+  </div>
+</section>
+
+<!-- Who benefits -->
+<section class="section section-alt">
+  <h2 class="section-title">Who Is This For?</h2>
+  <p class="section-subtitle">Anyone dealing with grouped .xlsx exports that need to become flat, queryable data.</p>
+  <div class="audience-grid">
+    <div class="audience-card">
+      <span class="label label-analyst">Data Analyst</span>
+      <h3>Analysts cleaning monthly reports</h3>
+      <p>You get a grouped .xlsx export from finance, HR, or sales every week. You need flat rows for pivot tables, SQL queries, or BI tools. xlfilldown fills the gaps and gives you a clean sheet or SQLite database in one command.</p>
+    </div>
+    <div class="audience-card">
+      <span class="label label-engineer">Data Engineer</span>
+      <h3>Engineers building data pipelines</h3>
+      <p>You need a lightweight, scriptable step in your ETL pipeline to normalize .xlsx inputs before loading into a warehouse. xlfilldown streams rows in constant memory, adds row hashes for deduplication, and needs only openpyxl as a dependency.</p>
+    </div>
+    <div class="audience-card">
+      <span class="label label-pipeline">DevOps / Automation</span>
+      <h3>Automation in CI/CD or cron</h3>
+      <p>Drop a single CLI command into your pipeline. No Python script to maintain - just <code class="inline">xlfilldown db</code> with the right flags. Schedule it with cron, run it in a container, or trigger it from Airflow.</p>
+    </div>
+    <div class="audience-card">
+      <span class="label label-analyst">Local User</span>
+      <h3>Running locally on your laptop</h3>
+      <p>Install with pip or pipx, run the command, open the output. No server needed, no cloud uploads. Your data stays on your machine. Perfect for one-off cleanup or quick ad-hoc analysis.</p>
+    </div>
+    <div class="audience-card">
+      <span class="label label-engineer">Python Developer</span>
+      <h3>Embedding in your app</h3>
+      <p>Use the Python API directly. Two functions - <code class="inline">ingest_excel_to_sqlite()</code> and <code class="inline">ingest_excel_to_excel()</code> - with clear return summaries. Build upload endpoints, batch processors, or data quality checks on top.</p>
+    </div>
+    <div class="audience-card">
+      <span class="label label-pipeline">QA / Audit</span>
+      <h3>Audit trails and data validation</h3>
+      <p>Every row carries its original Excel row number and a SHA-256 hash. Trace any database record back to the source spreadsheet line. Detect duplicates. Verify data integrity after transformation.</p>
+    </div>
+  </div>
+</section>
+
+<!-- Features Grid -->
+<section class="section">
+  <h2 class="section-title">Features</h2>
+  <p class="section-subtitle">Everything you need to go from messy .xlsx to clean, queryable data.</p>
+  <div class="features-grid">
+    <div class="feature-card">
+      <div class="feature-icon">&#x2B07;&#xFE0F;</div>
+      <h3>Hierarchical fill-down</h3>
+      <p>When a parent column changes, child columns reset automatically. Region &gt; Country &gt; City stays correct across group boundaries.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#x1F501;</div>
+      <h3>Independent fill mode</h3>
+      <p>Pandas-style ffill where each column carries forward on its own. No resets, no dependencies between columns.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#x1F4BE;</div>
+      <h3>SQLite &amp; Excel output</h3>
+      <p>Write to a SQLite database or a new .xlsx file. Same input flags for both. Choose your destination, xlfilldown handles the rest.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#x1F512;</div>
+      <h3>SHA-256 row hashes</h3>
+      <p>Stable, deterministic hashes over all columns after filling. Use for deduplication, change detection, and audit trails.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#x1F4CB;</div>
+      <h3>Excel row numbers</h3>
+      <p>Preserve the original 1-based row number from the source file. Trace any output record back to the exact spreadsheet line.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#x26A1;</div>
+      <h3>Streaming &amp; constant memory</h3>
+      <p>Uses openpyxl read-only mode. Rows stream through without loading the entire sheet into memory. Handles large files efficiently.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#x1F6AB;</div>
+      <h3>Row filtering</h3>
+      <p>Drop blank spacer rows or require specific columns to be non-null after filling. Clean output without post-processing.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#x1F4E5;</div>
+      <h3>Raw ingest mode</h3>
+      <p>Skip fill-down entirely. Just load the sheet as-is with optional audit columns. Useful for raw copies and baseline comparisons.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#x1F6E0;&#xFE0F;</div>
+      <h3>Minimal dependencies</h3>
+      <p>Only requires openpyxl. No pandas, no numpy, no heavy frameworks. Installs fast, stays lean.</p>
+    </div>
+  </div>
+</section>
+
+<!-- Quick Start -->
+<section class="section section-alt">
+  <h2 class="section-title">Quick Start</h2>
+  <p class="section-subtitle">From install to clean data in under a minute.</p>
+  <div class="quickstart">
+    <div class="step">
+      <div class="step-num">1</div>
+      <div class="step-content">
+        <h3>Install</h3>
+        <p>Grab it from PyPI with pip or pipx. Python 3.9+ required.</p>
+        <pre class="code-block"><span class="prompt" style="color:#64748b">$</span> pip install xlfilldown</pre>
+      </div>
+    </div>
+    <div class="step">
+      <div class="step-num">2</div>
+      <div class="step-content">
+        <h3>Fill down to SQLite</h3>
+        <p>Point at your .xlsx, name the columns to fill, and pick a database.</p>
+        <pre class="code-block"><span class="prompt" style="color:#64748b">$</span> xlfilldown db \
+    <span class="op">--infile</span> <span class="string">report.xlsx</span> \
+    <span class="op">--insheet</span> <span class="string">"Sheet1"</span> \
+    <span class="op">--header-row</span> <span class="nb">1</span> \
+    <span class="op">--fill-cols</span> <span class="string">'["Region","Country"]'</span> \
+    <span class="op">--db</span> <span class="string">output.db</span> \
+    <span class="op">--row-hash</span> <span class="op">--excel-row-numbers</span></pre>
+      </div>
+    </div>
+    <div class="step">
+      <div class="step-num">3</div>
+      <div class="step-content">
+        <h3>Or fill down to a new .xlsx</h3>
+        <p>Same flags, different destination. Output a clean, filled spreadsheet.</p>
+        <pre class="code-block"><span class="prompt" style="color:#64748b">$</span> xlfilldown xlsx \
+    <span class="op">--infile</span> <span class="string">report.xlsx</span> \
+    <span class="op">--insheet</span> <span class="string">"Sheet1"</span> \
+    <span class="op">--header-row</span> <span class="nb">1</span> \
+    <span class="op">--fill-cols-letters</span> <span class="nb">A B</span> \
+    <span class="op">--outfile</span> <span class="string">filled.xlsx</span></pre>
+      </div>
+    </div>
+    <div class="step">
+      <div class="step-num">4</div>
+      <div class="step-content">
+        <h3>Use the Python API</h3>
+        <p>Two functions, clear return values. Embed in Flask, FastAPI, Airflow, or any script.</p>
+        <pre class="code-block"><span class="kw">from</span> xlfilldown.api <span class="kw">import</span> <span class="fn">ingest_excel_to_sqlite</span>
+
+summary = <span class="fn">ingest_excel_to_sqlite</span>(
+    file=<span class="string">"report.xlsx"</span>,
+    sheet=<span class="string">"Sheet1"</span>,
+    header_row=<span class="nb">1</span>,
+    fill_cols=[<span class="string">"Region"</span>, <span class="string">"Country"</span>],
+    db=<span class="string">"output.db"</span>,
+)
+<span class="comment"># Returns: {table, columns, rows_ingested, row_hash, excel_row_numbers}</span></pre>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Compatibility -->
+<section class="section">
+  <h2 class="section-title">Compatibility</h2>
+  <p class="section-subtitle">Tested and supported across Python and openpyxl versions.</p>
+  <div class="compat-grid">
+    <div class="compat-card">
+      <span class="version">3.9+</span>
+      <span class="label">Python</span>
+    </div>
+    <div class="compat-card">
+      <span class="version">3.1.0+</span>
+      <span class="label">openpyxl</span>
+    </div>
+    <div class="compat-card">
+      <span class="version">.xlsx</span>
+      <span class="label">OOXML format</span>
+    </div>
+    <div class="compat-card">
+      <span class="version">SQLite 3</span>
+      <span class="label">Database output</span>
+    </div>
+    <div class="compat-card">
+      <span class="version">MIT</span>
+      <span class="label">License</span>
+    </div>
+    <div class="compat-card">
+      <span class="version">v1.0.3</span>
+      <span class="label">Current release</span>
+    </div>
+  </div>
+</section>
+
+<!-- Footer -->
+<footer class="site-footer">
+  <div class="footer-inner">
+    <div class="footer-brand">
+      <h3>xlf<span>ill</span>down</h3>
+      <p>A Python library for filling down values in .xlsx spreadsheets (OOXML). Stream into SQLite or a new Excel sheet with forward-fill padding, preserved row numbers, and stable SHA-256 row hashes.</p>
+    </div>
+    <div class="footer-links">
+      <h4>Documentation</h4>
+      <a href="index.html">Home</a>
+      <a href="reference.html">Reference Guide</a>
+      <a href="best_practices.html">Best Practices</a>
+    </div>
+    <div class="footer-links">
+      <h4>Project</h4>
+      <a href="https://github.com/RexBytes/xlfilldown">GitHub</a>
+      <a href="https://pypi.org/project/xlfilldown/">PyPI</a>
+      <a href="https://github.com/RexBytes/xlfilldown/releases">Changelog</a>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2025 RexBytes. MIT License.</span>
+    <p class="disclaimer">Not affiliated with or endorsed by Microsoft Corporation. "Excel" and ".xlsx" are trademarks or file formats associated with Microsoft. xlfilldown is an independent open-source Python package that reads and writes OOXML (.xlsx) files via the openpyxl library.</p>
+  </div>
+</footer>
+
+<!-- Demo Animation Script -->
+<script>
+(function() {
+  var currentStep = 1;
+  var totalSteps = 4;
+  var autoPlaying = false;
+  var autoTimer = null;
+
+  window.demoStep = function(dir) {
+    var next = currentStep + dir;
+    if (next < 1 || next > totalSteps) return;
+    currentStep = next;
+    render();
+  };
+
+  window.demoAutoPlay = function() {
+    if (autoPlaying) {
+      clearInterval(autoTimer);
+      autoPlaying = false;
+      document.getElementById('btn-auto').textContent = 'Auto Play';
+      return;
+    }
+    autoPlaying = true;
+    document.getElementById('btn-auto').textContent = 'Pause';
+    currentStep = 1;
+    render();
+    autoTimer = setInterval(function() {
+      currentStep++;
+      if (currentStep > totalSteps) {
+        currentStep = totalSteps;
+        clearInterval(autoTimer);
+        autoPlaying = false;
+        document.getElementById('btn-auto').textContent = 'Auto Play';
+      }
+      render();
+    }, 2000);
+  };
+
+  function render() {
+    document.getElementById('step-label').textContent = 'Step ' + currentStep + ' of ' + totalSteps;
+    document.getElementById('btn-prev').disabled = currentStep <= 1;
+    document.getElementById('btn-next').disabled = currentStep >= totalSteps;
+
+    var panelOutput = document.getElementById('panel-output');
+    var demoCommand = document.getElementById('demo-command');
+    var demoDb = document.getElementById('demo-db');
+
+    // Step 1: Show input only
+    if (currentStep === 1) {
+      panelOutput.style.opacity = '0.3';
+      hideFilledCells();
+      demoCommand.style.display = 'none';
+      demoDb.style.display = 'none';
+    }
+
+    // Step 2: Show output with filled cells animating in
+    if (currentStep >= 2) {
+      panelOutput.style.opacity = '1';
+      showFilledCells();
+    }
+
+    // Step 3: Show the command
+    if (currentStep >= 3) {
+      demoCommand.style.display = 'block';
+    } else {
+      demoCommand.style.display = 'none';
+    }
+
+    // Step 4: Show DB viewer
+    if (currentStep >= 4) {
+      demoDb.style.display = 'block';
+    } else {
+      demoDb.style.display = 'none';
+    }
+  }
+
+  function showFilledCells() {
+    var cells = document.querySelectorAll('.cell-filled-anim');
+    cells.forEach(function(cell, i) {
+      setTimeout(function() {
+        cell.classList.add('visible');
+      }, i * 80);
+    });
+  }
+
+  function hideFilledCells() {
+    var cells = document.querySelectorAll('.cell-filled-anim');
+    cells.forEach(function(cell) {
+      cell.classList.remove('visible');
+    });
+  }
+
+  // Initialize
+  render();
+})();
+</script>
+
+</body>
+</html>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -1,0 +1,620 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Reference Guide - xlfilldown</title>
+<meta name="description" content="Complete reference guide for xlfilldown: CLI commands, Python API, configuration options, and compatibility.">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #1a1a2e;
+  line-height: 1.7;
+  background: #fff;
+}
+a { color: #2563eb; text-decoration: none; }
+a:hover { text-decoration: underline; }
+code, pre { font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Consolas', monospace; }
+
+.site-header {
+  position: sticky; top: 0; z-index: 100;
+  background: linear-gradient(135deg, #1a1a2e, #16213e, #0f3460);
+  padding: 0 24px;
+  box-shadow: 0 2px 12px rgba(0,0,0,0.3);
+}
+.header-inner {
+  max-width: 1100px; margin: 0 auto;
+  display: flex; align-items: center; justify-content: space-between; height: 60px;
+}
+.logo { font-size: 1.25rem; font-weight: 700; color: #fff; letter-spacing: -0.5px; }
+.logo span { color: #60a5fa; }
+nav { display: flex; gap: 24px; align-items: center; }
+nav a { color: #cbd5e1; font-size: 0.9rem; font-weight: 500; transition: color 0.2s; text-decoration: none; }
+nav a:hover, nav a.active { color: #fff; text-decoration: none; }
+.nav-toggle { display: none; background: none; border: none; cursor: pointer; padding: 4px; }
+.nav-toggle span { display: block; width: 22px; height: 2px; background: #cbd5e1; margin: 5px 0; }
+
+.page-banner {
+  background: linear-gradient(135deg, #1a1a2e, #16213e, #0f3460);
+  padding: 56px 24px 48px; text-align: center;
+}
+.page-banner h1 { font-size: 2.4rem; font-weight: 700; color: #fff; margin-bottom: 8px; }
+.page-banner p { color: #94a3b8; font-size: 1.05rem; max-width: 600px; margin: 0 auto; }
+
+.content { max-width: 960px; margin: 0 auto; padding: 48px 24px 72px; }
+
+.toc {
+  background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 10px;
+  padding: 24px 28px; margin-bottom: 48px;
+}
+.toc h3 { font-size: 1rem; font-weight: 600; color: #1e3a5f; margin-bottom: 12px; }
+.toc ul { list-style: none; }
+.toc li { margin-bottom: 6px; }
+.toc a { font-size: 0.9rem; color: #2563eb; }
+.toc .sub { padding-left: 20px; }
+
+h2 {
+  font-size: 1.6rem; font-weight: 700; color: #1e3a5f;
+  margin-top: 56px; margin-bottom: 16px;
+  padding-bottom: 12px; border-bottom: 2px solid #e2e8f0;
+}
+h3 { font-size: 1.2rem; font-weight: 600; color: #1e3a5f; margin-top: 36px; margin-bottom: 12px; }
+h4 { font-size: 1.05rem; font-weight: 600; color: #374151; margin-top: 28px; margin-bottom: 8px; }
+h5 { font-size: 0.95rem; font-weight: 600; color: #475569; margin-top: 20px; margin-bottom: 6px; }
+p { margin-bottom: 14px; color: #374151; font-size: 0.95rem; }
+ul, ol { margin-bottom: 14px; padding-left: 24px; }
+li { margin-bottom: 6px; color: #374151; font-size: 0.93rem; }
+
+code.inline {
+  background: #e2e8f0; color: #1e293b; padding: 2px 8px; border-radius: 4px; font-size: 0.85em;
+}
+pre.code-block {
+  background: #1e293b; color: #e2e8f0; border-radius: 10px;
+  padding: 20px 24px; overflow-x: auto; font-size: 0.85rem; line-height: 1.7; margin-bottom: 20px;
+}
+.kw, .keyword { color: #93c5fd; }
+.fn { color: #fbbf24; }
+.st, .string { color: #86efac; }
+.cm, .comment { color: #64748b; }
+.op { color: #f472b6; }
+.nb { color: #c4b5fd; }
+
+.ref-table { width: 100%; border-collapse: collapse; margin-bottom: 24px; font-size: 0.88rem; }
+.ref-table th {
+  background: #1e3a5f; color: #fff; font-weight: 600;
+  padding: 10px 14px; text-align: left; font-size: 0.85rem;
+}
+.ref-table td { padding: 10px 14px; border-bottom: 1px solid #e2e8f0; color: #374151; vertical-align: top; }
+.ref-table tr:nth-child(even) td { background: #f1f5f9; }
+.ref-table tr:hover td { background: #e8f0fe; }
+
+.note {
+  background: #f0f9ff; border-left: 4px solid #2563eb;
+  padding: 16px 20px; border-radius: 0 8px 8px 0; margin-bottom: 20px;
+}
+.note p { margin-bottom: 0; color: #1e3a5f; font-size: 0.9rem; }
+.warning {
+  background: #fef3c7; border-left: 4px solid #f59e0b;
+  padding: 16px 20px; border-radius: 0 8px 8px 0; margin-bottom: 20px;
+}
+.warning p { margin-bottom: 0; color: #92400e; font-size: 0.9rem; }
+
+.site-footer {
+  background: linear-gradient(135deg, #1a1a2e, #16213e, #0f3460);
+  padding: 48px 24px 32px; color: #94a3b8; font-size: 0.85rem;
+}
+.footer-inner { max-width: 1100px; margin: 0 auto; display: grid; grid-template-columns: 2fr 1fr 1fr; gap: 40px; }
+.footer-brand h3 { color: #fff; font-size: 1.1rem; margin-bottom: 8px; }
+.footer-brand h3 span { color: #60a5fa; }
+.footer-links h4 { color: #cbd5e1; font-size: 0.9rem; margin-bottom: 12px; }
+.footer-links a { color: #94a3b8; display: block; margin-bottom: 6px; font-size: 0.85rem; }
+.footer-links a:hover { color: #fff; text-decoration: none; }
+.footer-bottom {
+  max-width: 1100px; margin: 32px auto 0; padding-top: 24px;
+  border-top: 1px solid rgba(255,255,255,0.1);
+  display: flex; justify-content: space-between; flex-wrap: wrap; gap: 12px;
+}
+.disclaimer { color: #64748b; font-size: 0.78rem; max-width: 600px; line-height: 1.5; }
+
+@media (max-width: 768px) {
+  .page-banner h1 { font-size: 1.8rem; }
+  .content { padding: 32px 16px 48px; }
+  .footer-inner { grid-template-columns: 1fr; gap: 24px; }
+  .footer-bottom { flex-direction: column; text-align: center; }
+  .ref-table { font-size: 0.8rem; }
+  .ref-table th, .ref-table td { padding: 8px 10px; }
+  .nav-toggle { display: block; }
+  nav.nav-closed { display: none; }
+  nav.nav-open { display: flex; width: 100%; padding: 12px 0; flex-wrap: wrap; justify-content: center; }
+  h2 { font-size: 1.35rem; }
+}
+</style>
+</head>
+<body>
+
+<header class="site-header">
+  <div class="header-inner">
+    <a href="index.html" class="logo">xlf<span>ill</span>down</a>
+    <button class="nav-toggle" onclick="document.querySelector('nav').classList.toggle('nav-open');document.querySelector('nav').classList.toggle('nav-closed')" aria-label="Toggle navigation">
+      <span></span><span></span><span></span>
+    </button>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="reference.html" class="active">Reference</a>
+      <a href="best_practices.html">Best Practices</a>
+      <a href="https://github.com/RexBytes/xlfilldown">GitHub</a>
+      <a href="https://pypi.org/project/xlfilldown/">PyPI</a>
+    </nav>
+  </div>
+</header>
+
+<section class="page-banner">
+  <h1>Reference Guide</h1>
+  <p>Complete documentation for the xlfilldown CLI and Python API.</p>
+</section>
+
+<div class="content">
+
+  <div class="toc">
+    <h3>Contents</h3>
+    <ul>
+      <li><a href="#overview">Overview</a></li>
+      <li><a href="#installation">Installation</a></li>
+      <li><a href="#cli">CLI Commands</a></li>
+      <li class="sub"><a href="#cli-common">Common Input Options</a></li>
+      <li class="sub"><a href="#cli-db">db Subcommand (SQLite)</a></li>
+      <li class="sub"><a href="#cli-xlsx">xlsx Subcommand (Excel)</a></li>
+      <li><a href="#python-api">Python API</a></li>
+      <li class="sub"><a href="#api-sqlite">ingest_excel_to_sqlite()</a></li>
+      <li class="sub"><a href="#api-excel">ingest_excel_to_excel()</a></li>
+      <li class="sub"><a href="#api-utilities">Utility Functions</a></li>
+      <li><a href="#fill-modes">Fill Modes</a></li>
+      <li class="sub"><a href="#fill-hierarchical">Hierarchical (default)</a></li>
+      <li class="sub"><a href="#fill-independent">Independent (pandas-style)</a></li>
+      <li><a href="#behavior">Behavior Details</a></li>
+      <li><a href="#sqlite-details">SQLite Output Details</a></li>
+      <li><a href="#excel-details">Excel Output Details</a></li>
+      <li><a href="#compatibility">Compatibility</a></li>
+    </ul>
+  </div>
+
+  <!-- Overview -->
+  <h2 id="overview">Overview</h2>
+  <p>xlfilldown is a Python library and CLI tool that streams an .xlsx (OOXML) sheet into SQLite or a new Excel sheet with forward-fill padding. It preserves original Excel row numbers and computes a stable SHA-256 row hash for audit purposes.</p>
+  <p>The tool ingests only columns with non-empty headers, stores all values as TEXT strings (numbers and dates are canonicalized to stable text), and streams rows in constant memory using openpyxl's read-only mode.</p>
+  <div class="note">
+    <p><strong>Key concept:</strong> "Fill-down" (or forward-fill) means populating empty cells with the last non-empty value from the same column. This is essential when working with grouped .xlsx exports where parent values appear only once per group.</p>
+  </div>
+
+  <!-- Installation -->
+  <h2 id="installation">Installation</h2>
+  <h3>From PyPI (recommended)</h3>
+  <pre class="code-block"><span class="comment"># Using pip</span>
+<span class="prompt" style="color:#64748b">$</span> pip install xlfilldown
+
+<span class="comment"># Using pipx (isolated environment)</span>
+<span class="prompt" style="color:#64748b">$</span> pipx install xlfilldown</pre>
+  <p>Requires Python &ge; 3.9. The only dependency is <code class="inline">openpyxl</code> &ge; 3.1.0.</p>
+
+  <h3>From source</h3>
+  <pre class="code-block"><span class="prompt" style="color:#64748b">$</span> git clone https://github.com/RexBytes/xlfilldown.git
+<span class="prompt" style="color:#64748b">$</span> cd xlfilldown
+<span class="prompt" style="color:#64748b">$</span> pip install .</pre>
+
+  <!-- CLI -->
+  <h2 id="cli">CLI Commands</h2>
+  <p>The <code class="inline">xlfilldown</code> command has two subcommands sharing the same input options:</p>
+  <ul>
+    <li><code class="inline">xlfilldown db</code> - write to a SQLite database</li>
+    <li><code class="inline">xlfilldown xlsx</code> - write to a new .xlsx file</li>
+  </ul>
+
+  <h3 id="cli-common">Common Input Options</h3>
+  <p>These options apply to both <code class="inline">db</code> and <code class="inline">xlsx</code> subcommands.</p>
+  <table class="ref-table">
+    <thead><tr><th>Option</th><th>Required</th><th>Default</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code class="inline">--infile</code></td><td>Yes</td><td>-</td><td>Path to the input .xlsx file.</td></tr>
+      <tr><td><code class="inline">--insheet</code></td><td>Yes</td><td>-</td><td>Sheet name to read from the input file.</td></tr>
+      <tr><td><code class="inline">--header-row</code></td><td>Yes</td><td>-</td><td>1-based row number containing column headers.</td></tr>
+      <tr><td><code class="inline">--fill-cols</code></td><td>No</td><td>-</td><td>JSON array of header names to forward-fill. Example: <code class="inline">'["Region","Country"]'</code>. Mutually exclusive with <code class="inline">--fill-cols-letters</code>.</td></tr>
+      <tr><td><code class="inline">--fill-cols-letters</code></td><td>No</td><td>-</td><td>Excel column letters to forward-fill, space-separated. Example: <code class="inline">A C AE</code>. Resolved to header names via <code class="inline">--header-row</code>. Mutually exclusive with <code class="inline">--fill-cols</code>.</td></tr>
+      <tr><td><code class="inline">--fill-mode</code></td><td>No</td><td><code class="inline">hierarchical</code></td><td><code class="inline">hierarchical</code> (higher-tier changes reset lower-tier carries) or <code class="inline">independent</code> (pandas-style ffill).</td></tr>
+      <tr><td><code class="inline">--ingest-mode</code></td><td>No</td><td><code class="inline">fill</code></td><td><code class="inline">fill</code> applies forward-fill. <code class="inline">raw</code> skips fill-down entirely.</td></tr>
+      <tr><td><code class="inline">--drop-blank-rows</code></td><td>No</td><td><code class="inline">False</code></td><td>Drop rows where all fill columns are empty after filling.</td></tr>
+      <tr><td><code class="inline">--require-non-null</code></td><td>No</td><td>-</td><td>JSON array of headers. Drop row if any are null/blank after fill.</td></tr>
+      <tr><td><code class="inline">--require-non-null-letters</code></td><td>No</td><td>-</td><td>Excel column letters for require-non-null. Merged with <code class="inline">--require-non-null</code>.</td></tr>
+      <tr><td><code class="inline">--row-hash</code></td><td>No</td><td><code class="inline">False</code></td><td>Include a <code class="inline">row_hash</code> column (SHA-256 hex digest over all columns after filling).</td></tr>
+      <tr><td><code class="inline">--excel-row-numbers</code></td><td>No</td><td><code class="inline">False</code></td><td>Include an <code class="inline">excel_row</code> column with the original 1-based row number.</td></tr>
+      <tr><td><code class="inline">--if-exists</code></td><td>No</td><td><code class="inline">fail</code></td><td><code class="inline">fail</code>, <code class="inline">replace</code>, or <code class="inline">append</code>.</td></tr>
+    </tbody>
+  </table>
+
+  <!-- db subcommand -->
+  <h3 id="cli-db">db Subcommand (SQLite Output)</h3>
+  <table class="ref-table">
+    <thead><tr><th>Option</th><th>Required</th><th>Default</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code class="inline">--db</code></td><td>Yes</td><td>-</td><td>SQLite database file path (created if missing).</td></tr>
+      <tr><td><code class="inline">--table</code></td><td>No</td><td>Derived from sheet</td><td>SQLite table name.</td></tr>
+      <tr><td><code class="inline">--batch-size</code></td><td>No</td><td><code class="inline">1000</code></td><td>Rows per <code class="inline">executemany()</code> batch.</td></tr>
+    </tbody>
+  </table>
+
+  <h4>Example: Hierarchical fill to SQLite</h4>
+  <pre class="code-block"><span class="prompt" style="color:#64748b">$</span> xlfilldown db \
+    <span class="op">--infile</span> <span class="string">sales_report.xlsx</span> \
+    <span class="op">--insheet</span> <span class="string">"Sheet1"</span> \
+    <span class="op">--header-row</span> <span class="nb">1</span> \
+    <span class="op">--fill-cols</span> <span class="string">'["Region","Country","City"]'</span> \
+    <span class="op">--db</span> <span class="string">sales.db</span> \
+    <span class="op">--row-hash</span> \
+    <span class="op">--excel-row-numbers</span></pre>
+
+  <h4>Example: Fill by column letters</h4>
+  <pre class="code-block"><span class="prompt" style="color:#64748b">$</span> xlfilldown db \
+    <span class="op">--infile</span> <span class="string">data.xlsx</span> \
+    <span class="op">--insheet</span> <span class="string">"Sheet1"</span> \
+    <span class="op">--header-row</span> <span class="nb">1</span> \
+    <span class="op">--fill-cols-letters</span> <span class="nb">A C AE</span> \
+    <span class="op">--db</span> <span class="string">out.db</span></pre>
+
+  <h4>Example: Append with row filtering</h4>
+  <pre class="code-block"><span class="prompt" style="color:#64748b">$</span> xlfilldown db \
+    <span class="op">--infile</span> <span class="string">report.xlsx</span> \
+    <span class="op">--insheet</span> <span class="string">"Data"</span> \
+    <span class="op">--header-row</span> <span class="nb">2</span> \
+    <span class="op">--fill-cols</span> <span class="string">'["Category","Subcategory"]'</span> \
+    <span class="op">--drop-blank-rows</span> \
+    <span class="op">--require-non-null</span> <span class="string">'["Category"]'</span> \
+    <span class="op">--db</span> <span class="string">warehouse.db</span> \
+    <span class="op">--table</span> <span class="string">products</span> \
+    <span class="op">--if-exists</span> <span class="string">append</span></pre>
+
+  <h4>Example: Raw ingest (no fill-down)</h4>
+  <pre class="code-block"><span class="prompt" style="color:#64748b">$</span> xlfilldown db \
+    <span class="op">--infile</span> <span class="string">data.xlsx</span> \
+    <span class="op">--insheet</span> <span class="string">"Sheet1"</span> \
+    <span class="op">--header-row</span> <span class="nb">1</span> \
+    <span class="op">--ingest-mode</span> <span class="string">raw</span> \
+    <span class="op">--db</span> <span class="string">out.db</span> \
+    <span class="op">--row-hash</span> \
+    <span class="op">--excel-row-numbers</span> \
+    <span class="op">--if-exists</span> <span class="string">replace</span></pre>
+
+  <!-- xlsx subcommand -->
+  <h3 id="cli-xlsx">xlsx Subcommand (Excel Output)</h3>
+  <table class="ref-table">
+    <thead><tr><th>Option</th><th>Required</th><th>Default</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code class="inline">--outfile</code></td><td>Yes</td><td>-</td><td>Output .xlsx file path.</td></tr>
+      <tr><td><code class="inline">--outsheet</code></td><td>No</td><td>Derived from input</td><td>Output sheet name.</td></tr>
+    </tbody>
+  </table>
+
+  <h4>Example: Fill by header names to Excel</h4>
+  <pre class="code-block"><span class="prompt" style="color:#64748b">$</span> xlfilldown xlsx \
+    <span class="op">--infile</span> <span class="string">data.xlsx</span> \
+    <span class="op">--insheet</span> <span class="string">"Sheet1"</span> \
+    <span class="op">--header-row</span> <span class="nb">1</span> \
+    <span class="op">--fill-cols</span> <span class="string">'["Region","Country","City"]'</span> \
+    <span class="op">--outfile</span> <span class="string">filled.xlsx</span> \
+    <span class="op">--outsheet</span> <span class="string">Processed</span></pre>
+
+  <h4>Example: Fill by column letters to Excel</h4>
+  <pre class="code-block"><span class="prompt" style="color:#64748b">$</span> xlfilldown xlsx \
+    <span class="op">--infile</span> <span class="string">data.xlsx</span> \
+    <span class="op">--insheet</span> <span class="string">"Sheet1"</span> \
+    <span class="op">--header-row</span> <span class="nb">1</span> \
+    <span class="op">--fill-cols-letters</span> <span class="nb">A D</span> \
+    <span class="op">--outfile</span> <span class="string">out.xlsx</span></pre>
+
+  <h4>Example: Raw ingest to Excel</h4>
+  <pre class="code-block"><span class="prompt" style="color:#64748b">$</span> xlfilldown xlsx \
+    <span class="op">--infile</span> <span class="string">data.xlsx</span> \
+    <span class="op">--insheet</span> <span class="string">"Sheet1"</span> \
+    <span class="op">--header-row</span> <span class="nb">1</span> \
+    <span class="op">--ingest-mode</span> <span class="string">raw</span> \
+    <span class="op">--outfile</span> <span class="string">raw_copy.xlsx</span> \
+    <span class="op">--outsheet</span> <span class="string">RawSheet</span> \
+    <span class="op">--row-hash</span> \
+    <span class="op">--excel-row-numbers</span> \
+    <span class="op">--if-exists</span> <span class="string">replace</span></pre>
+
+  <!-- Python API -->
+  <h2 id="python-api">Python API</h2>
+  <p>Import from <code class="inline">xlfilldown.api</code>:</p>
+  <pre class="code-block"><span class="kw">from</span> xlfilldown.api <span class="kw">import</span> <span class="fn">ingest_excel_to_sqlite</span>, <span class="fn">ingest_excel_to_excel</span></pre>
+
+  <h3 id="api-sqlite">ingest_excel_to_sqlite()</h3>
+  <p>Stream an .xlsx sheet into a SQLite database table with optional forward-fill, row hashing, and row number preservation.</p>
+
+  <h4>Signature</h4>
+  <pre class="code-block"><span class="kw">def</span> <span class="fn">ingest_excel_to_sqlite</span>(
+    file: <span class="nb">str</span> | <span class="nb">Path</span>,              <span class="comment"># Input .xlsx file path</span>
+    sheet: <span class="nb">str</span>,                     <span class="comment"># Sheet name to read</span>
+    header_row: <span class="nb">int</span>,                <span class="comment"># 1-based header row</span>
+    fill_cols: <span class="nb">Optional</span>[<span class="nb">Sequence</span>[<span class="nb">str</span>]] = <span class="nb">None</span>,         <span class="comment"># Fill by header names</span>
+    fill_cols_letters: <span class="nb">Optional</span>[<span class="nb">Sequence</span>[<span class="nb">str</span>]] = <span class="nb">None</span>,  <span class="comment"># Fill by column letters</span>
+    fill_mode: <span class="nb">Optional</span>[<span class="nb">str</span>] = <span class="nb">None</span>,       <span class="comment"># "hierarchical" | "independent"</span>
+    ingest_mode: <span class="nb">str</span> = <span class="string">"fill"</span>,            <span class="comment"># "fill" | "raw"</span>
+    drop_blank_rows: <span class="nb">bool</span> = <span class="nb">False</span>,
+    require_non_null: <span class="nb">Optional</span>[<span class="nb">Sequence</span>[<span class="nb">str</span>]] = <span class="nb">None</span>,
+    require_non_null_letters: <span class="nb">Optional</span>[<span class="nb">Sequence</span>[<span class="nb">str</span>]] = <span class="nb">None</span>,
+    row_hash: <span class="nb">bool</span> = <span class="nb">False</span>,
+    excel_row_numbers: <span class="nb">bool</span> = <span class="nb">False</span>,
+    db: <span class="nb">str</span> | <span class="nb">Path</span>,                  <span class="comment"># SQLite database file</span>
+    table: <span class="nb">Optional</span>[<span class="nb">str</span>] = <span class="nb">None</span>,    <span class="comment"># Table name (default: sheet name)</span>
+    batch_size: <span class="nb">int</span> = <span class="nb">1000</span>,
+    if_exists: <span class="nb">str</span> = <span class="string">"fail"</span>,         <span class="comment"># "fail" | "replace" | "append"</span>
+) -> <span class="nb">dict</span></pre>
+
+  <h4>Return value</h4>
+  <table class="ref-table">
+    <thead><tr><th>Key</th><th>Type</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code class="inline">table</code></td><td>str</td><td>SQLite table name used.</td></tr>
+      <tr><td><code class="inline">columns</code></td><td>list</td><td>List of column names in the table.</td></tr>
+      <tr><td><code class="inline">rows_ingested</code></td><td>int</td><td>Number of rows written.</td></tr>
+      <tr><td><code class="inline">row_hash</code></td><td>bool</td><td>Whether row hashing was enabled.</td></tr>
+      <tr><td><code class="inline">excel_row_numbers</code></td><td>bool</td><td>Whether Excel row numbers were included.</td></tr>
+    </tbody>
+  </table>
+
+  <h4>Example</h4>
+  <pre class="code-block"><span class="kw">from</span> xlfilldown.api <span class="kw">import</span> <span class="fn">ingest_excel_to_sqlite</span>
+
+summary = <span class="fn">ingest_excel_to_sqlite</span>(
+    file=<span class="string">"sales_report.xlsx"</span>,
+    sheet=<span class="string">"Sheet1"</span>,
+    header_row=<span class="nb">1</span>,
+    fill_cols=[<span class="string">"Region"</span>, <span class="string">"Country"</span>, <span class="string">"City"</span>],
+    fill_mode=<span class="string">"hierarchical"</span>,
+    db=<span class="string">"sales.db"</span>,
+    row_hash=<span class="nb">True</span>,
+    excel_row_numbers=<span class="nb">True</span>,
+    drop_blank_rows=<span class="nb">True</span>,
+    if_exists=<span class="string">"replace"</span>,
+)
+
+<span class="nb">print</span>(<span class="string">f"Table: </span>{summary[<span class="string">'table'</span>]}<span class="string">"</span>)
+<span class="nb">print</span>(<span class="string">f"Rows: </span>{summary[<span class="string">'rows_ingested'</span>]}<span class="string">"</span>)</pre>
+
+  <h3 id="api-excel">ingest_excel_to_excel()</h3>
+  <p>Stream an .xlsx sheet into a new Excel sheet with optional forward-fill, row hashing, and row number preservation.</p>
+
+  <h4>Signature</h4>
+  <pre class="code-block"><span class="kw">def</span> <span class="fn">ingest_excel_to_excel</span>(
+    file: <span class="nb">str</span> | <span class="nb">Path</span>,
+    sheet: <span class="nb">str</span>,
+    header_row: <span class="nb">int</span>,
+    fill_cols: <span class="nb">Optional</span>[<span class="nb">Sequence</span>[<span class="nb">str</span>]] = <span class="nb">None</span>,
+    fill_cols_letters: <span class="nb">Optional</span>[<span class="nb">Sequence</span>[<span class="nb">str</span>]] = <span class="nb">None</span>,
+    fill_mode: <span class="nb">Optional</span>[<span class="nb">str</span>] = <span class="nb">None</span>,
+    ingest_mode: <span class="nb">str</span> = <span class="string">"fill"</span>,
+    drop_blank_rows: <span class="nb">bool</span> = <span class="nb">False</span>,
+    require_non_null: <span class="nb">Optional</span>[<span class="nb">Sequence</span>[<span class="nb">str</span>]] = <span class="nb">None</span>,
+    require_non_null_letters: <span class="nb">Optional</span>[<span class="nb">Sequence</span>[<span class="nb">str</span>]] = <span class="nb">None</span>,
+    row_hash: <span class="nb">bool</span> = <span class="nb">False</span>,
+    excel_row_numbers: <span class="nb">bool</span> = <span class="nb">False</span>,
+    outfile: <span class="nb">str</span> | <span class="nb">Path</span>,
+    outsheet: <span class="nb">Optional</span>[<span class="nb">str</span>] = <span class="nb">None</span>,
+    if_exists: <span class="nb">str</span> = <span class="string">"fail"</span>,
+) -> <span class="nb">dict</span></pre>
+
+  <h4>Return value</h4>
+  <table class="ref-table">
+    <thead><tr><th>Key</th><th>Type</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code class="inline">workbook</code></td><td>str</td><td>Output workbook file path.</td></tr>
+      <tr><td><code class="inline">sheet</code></td><td>str</td><td>Output sheet name.</td></tr>
+      <tr><td><code class="inline">columns</code></td><td>list</td><td>List of column names written.</td></tr>
+      <tr><td><code class="inline">rows_written</code></td><td>int</td><td>Number of rows written.</td></tr>
+      <tr><td><code class="inline">row_hash</code></td><td>bool</td><td>Whether row hashing was enabled.</td></tr>
+      <tr><td><code class="inline">excel_row_numbers</code></td><td>bool</td><td>Whether Excel row numbers were included.</td></tr>
+    </tbody>
+  </table>
+
+  <h4>Example</h4>
+  <pre class="code-block"><span class="kw">from</span> xlfilldown.api <span class="kw">import</span> <span class="fn">ingest_excel_to_excel</span>
+
+summary = <span class="fn">ingest_excel_to_excel</span>(
+    file=<span class="string">"data.xlsx"</span>,
+    sheet=<span class="string">"Sheet1"</span>,
+    header_row=<span class="nb">1</span>,
+    fill_cols=[<span class="string">"Region"</span>, <span class="string">"Country"</span>],
+    fill_mode=<span class="string">"independent"</span>,
+    outfile=<span class="string">"filled.xlsx"</span>,
+    outsheet=<span class="string">"Processed"</span>,
+    row_hash=<span class="nb">True</span>,
+    excel_row_numbers=<span class="nb">True</span>,
+    if_exists=<span class="string">"replace"</span>,
+)
+
+<span class="nb">print</span>(<span class="string">f"Wrote </span>{summary[<span class="string">'rows_written'</span>]}<span class="string"> rows to </span>{summary[<span class="string">'workbook'</span>]}<span class="string">"</span>)</pre>
+
+  <h3 id="api-utilities">Utility Functions</h3>
+  <p>Re-exported from <code class="inline">xlfilldown.api</code> for advanced use:</p>
+  <table class="ref-table">
+    <thead><tr><th>Function</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code class="inline">normalize_headers(cells)</code></td><td>Normalize header cell values: trim whitespace, coerce None/blank/"nan" to empty strings. Returns a list of strings.</td></tr>
+      <tr><td><code class="inline">canon_list(values)</code></td><td>Canonicalize a sequence of values to a JSON-format string. Used internally for hash computation.</td></tr>
+      <tr><td><code class="inline">sha256_hex(s)</code></td><td>Compute the SHA-256 hex digest of a string.</td></tr>
+      <tr><td><code class="inline">qident(name)</code></td><td>Quote a SQLite identifier (table or column name) safely.</td></tr>
+    </tbody>
+  </table>
+
+  <!-- Fill Modes -->
+  <h2 id="fill-modes">Fill Modes</h2>
+
+  <h3 id="fill-hierarchical">Hierarchical (default)</h3>
+  <p>In hierarchical mode, the order of columns matters. The first column is the highest tier. When a higher-tier column receives a new value, all lower-tier carries reset.</p>
+  <div class="note">
+    <p><strong>Think of it as:</strong> Region &gt; Country &gt; City. When a new Region appears, Country and City reset. When a new Country appears, only City resets.</p>
+  </div>
+  <p>Input:</p>
+  <pre class="code-block">Region     Country    City
+EMEA       UK         London
+                      Manchester
+           Germany    Berlin
+                      Munich
+APAC       Japan      Tokyo</pre>
+  <p>Hierarchical output with <code class="inline">--fill-cols '["Region","Country","City"]'</code>:</p>
+  <pre class="code-block">Region     Country    City
+EMEA       UK         London
+<span class="string">EMEA</span>       <span class="string">UK</span>         Manchester    <span class="comment"># Region and Country filled from above</span>
+<span class="string">EMEA</span>       Germany    Berlin        <span class="comment"># Country changed; City has own value</span>
+<span class="string">EMEA</span>       <span class="string">Germany</span>    Munich        <span class="comment"># Both filled</span>
+APAC       Japan      Tokyo         <span class="comment"># Region changed; lower tiers reset</span></pre>
+
+  <div class="warning">
+    <p><strong>Important:</strong> "Reset" means the carry is cleared for that row. If the row has its own value for a lower-tier column (like "Berlin" above), that value is kept. The reset only affects empty cells that would otherwise carry a stale value.</p>
+  </div>
+
+  <h3 id="fill-independent">Independent (pandas-style)</h3>
+  <p>Each column fills forward on its own. Column order does not matter. Columns do not reset each other.</p>
+  <p>Same input, with <code class="inline">--fill-mode independent</code>:</p>
+  <pre class="code-block">Region     Country    City
+EMEA       UK         London
+<span class="string">EMEA</span>       <span class="string">UK</span>         Manchester    <span class="comment"># UK carries independently</span>
+<span class="string">EMEA</span>       Germany    Berlin
+<span class="string">EMEA</span>       <span class="string">Germany</span>    Munich
+APAC       Japan      Tokyo</pre>
+
+  <!-- Behavior Details -->
+  <h2 id="behavior">Behavior Details</h2>
+
+  <h3>Headers</h3>
+  <ul>
+    <li>Only columns with non-empty headers on <code class="inline">--header-row</code> are ingested.</li>
+    <li>Normalization: whitespace trimmed, case preserved, <code class="inline">"nan"</code> string converted to empty.</li>
+    <li>Empty or duplicate headers after normalization are rejected with a clear error.</li>
+    <li>When using <code class="inline">--fill-cols-letters</code>, each referenced column must have a non-empty header.</li>
+  </ul>
+
+  <h3>Cell treatment</h3>
+  <ul>
+    <li>All values stored as <strong>TEXT</strong> (including numbers, dates, <code class="inline">excel_row</code>).</li>
+    <li>Whitespace-only cells treated as blank.</li>
+    <li>None/blank/whitespace normalize to NULL (empty).</li>
+    <li>Numbers canonicalized to stable text: <code class="inline">1</code> and <code class="inline">1.0</code> both become <code class="inline">"1"</code>. No scientific notation.</li>
+    <li>Dates converted to ISO format.</li>
+    <li>Strings stripped of leading/trailing whitespace.</li>
+  </ul>
+
+  <h3>Row hash</h3>
+  <ul>
+    <li>SHA-256 hex digest over <strong>all ingested columns</strong> (in header order) <strong>after</strong> filling.</li>
+    <li>For completely empty rows, the hash reflects all-empty values.</li>
+    <li>Numbers normalized before hashing (same canonicalization as storage).</li>
+    <li>In SQLite mode, a non-unique index is created on <code class="inline">row_hash</code>.</li>
+  </ul>
+
+  <h3>Row filtering</h3>
+  <ul>
+    <li><code class="inline">--drop-blank-rows</code>: drops rows where <strong>all</strong> fill columns are blank after filling.</li>
+    <li><code class="inline">--require-non-null</code>: drops rows where <strong>any</strong> specified headers are blank after filling.</li>
+    <li>Both can be combined. Filters run <strong>after</strong> fill-down logic.</li>
+  </ul>
+
+  <h3>Completely empty rows</h3>
+  <ul>
+    <li>Rows where all columns are blank are treated as spacer rows.</li>
+    <li>No fill-down is applied to them, but the carry persists past them.</li>
+    <li>Dropped if <code class="inline">--drop-blank-rows</code> is enabled.</li>
+  </ul>
+
+  <h3>Raw ingest mode</h3>
+  <p>Set <code class="inline">--ingest-mode raw</code> to skip fill-down entirely.</p>
+  <ul>
+    <li><code class="inline">--fill-cols</code> / <code class="inline">--fill-cols-letters</code> ignored (no error raised).</li>
+    <li>Row filtering (<code class="inline">--drop-blank-rows</code>, <code class="inline">--require-non-null</code>) still applies.</li>
+    <li>Audit columns (<code class="inline">--row-hash</code>, <code class="inline">--excel-row-numbers</code>) still work.</li>
+    <li>Useful for raw copies with audit columns or baseline comparisons.</li>
+  </ul>
+
+  <!-- SQLite details -->
+  <h2 id="sqlite-details">SQLite Output Details</h2>
+  <h4>Schema</h4>
+  <ul>
+    <li>All columns are <strong>TEXT</strong> type.</li>
+    <li>Column order: <code class="inline">[row_hash] [excel_row] headers...</code></li>
+    <li>Indexes created automatically on <code class="inline">excel_row</code> and <code class="inline">row_hash</code> when enabled.</li>
+  </ul>
+  <h4>Append mode</h4>
+  <ul>
+    <li>Existing table schema must exactly match the expected column order.</li>
+    <li>Validated using <code class="inline">PRAGMA table_info()</code> before inserting.</li>
+  </ul>
+  <h4>Workbook reading</h4>
+  <ul>
+    <li>Input opened with <code class="inline">read_only=True, data_only=True</code>.</li>
+    <li>Formulas use cached values (last computed result).</li>
+  </ul>
+
+  <!-- Excel output details -->
+  <h2 id="excel-details">Excel Output Details</h2>
+  <h4>Sheet-level --if-exists</h4>
+  <table class="ref-table">
+    <thead><tr><th>Value</th><th>Behavior</th></tr></thead>
+    <tbody>
+      <tr><td><code class="inline">fail</code></td><td>Error if the target sheet already exists.</td></tr>
+      <tr><td><code class="inline">replace</code></td><td>Recreate the target sheet fresh.</td></tr>
+      <tr><td><code class="inline">append</code></td><td>Append below existing rows. Destination header must match expected list.</td></tr>
+    </tbody>
+  </table>
+  <h4>Optimization</h4>
+  <ul>
+    <li>Uses <code class="inline">write_only=True</code> for new workbooks (streaming writes).</li>
+    <li>Regular write mode for existing workbooks (to support append/replace).</li>
+  </ul>
+
+  <!-- Compatibility -->
+  <h2 id="compatibility">Compatibility</h2>
+  <table class="ref-table">
+    <thead><tr><th>Requirement</th><th>Version</th><th>Notes</th></tr></thead>
+    <tbody>
+      <tr><td>Python</td><td>&ge; 3.9</td><td>Tested on 3.9 through 3.13</td></tr>
+      <tr><td>openpyxl</td><td>&ge; 3.1.0</td><td>Only runtime dependency</td></tr>
+      <tr><td>Input format</td><td>.xlsx (OOXML)</td><td>Does not support .xls (legacy binary)</td></tr>
+      <tr><td>Output (DB)</td><td>SQLite 3</td><td>Python built-in sqlite3 module</td></tr>
+      <tr><td>Output (Excel)</td><td>.xlsx (OOXML)</td><td>Via openpyxl</td></tr>
+      <tr><td>OS</td><td>Any</td><td>Windows, macOS, Linux</td></tr>
+      <tr><td>License</td><td>MIT</td><td>Free for commercial and personal use</td></tr>
+    </tbody>
+  </table>
+
+</div>
+
+<footer class="site-footer">
+  <div class="footer-inner">
+    <div class="footer-brand">
+      <h3>xlf<span>ill</span>down</h3>
+      <p>A Python library for filling down values in .xlsx spreadsheets (OOXML).</p>
+    </div>
+    <div class="footer-links">
+      <h4>Documentation</h4>
+      <a href="index.html">Home</a>
+      <a href="reference.html">Reference Guide</a>
+      <a href="best_practices.html">Best Practices</a>
+    </div>
+    <div class="footer-links">
+      <h4>Project</h4>
+      <a href="https://github.com/RexBytes/xlfilldown">GitHub</a>
+      <a href="https://pypi.org/project/xlfilldown/">PyPI</a>
+      <a href="https://github.com/RexBytes/xlfilldown/releases">Changelog</a>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2025 RexBytes. MIT License.</span>
+    <p class="disclaimer">Not affiliated with or endorsed by Microsoft Corporation. "Excel" and ".xlsx" are trademarks or file formats associated with Microsoft. xlfilldown is an independent open-source Python package that reads and writes OOXML (.xlsx) files via the openpyxl library.</p>
+  </div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
- index.html: Landing page with interactive fill-down demo (animated spreadsheet before/after, SQLite viewer, click-along walkthrough), problem/solution narrative, audience cards, feature grid, quickstart steps, and compatibility section
- reference.html: Complete reference guide covering CLI commands (db/xlsx subcommands, all options), Python API (signatures, return values, utility functions), fill modes, behavior details, and compatibility
- best_practices.html: Recipe cards for CLI patterns, Python API usage, framework integrations (Flask, FastAPI, Airflow), data quality patterns (deduplication, audit trails), and quick reference tables

All pages use self-contained inline CSS, Google Fonts Inter, responsive design with 768px breakpoints, consistent nav/footer, and Microsoft non-affiliation disclaimer.

https://claude.ai/code/session_01EAwPBzteNK5gfRnuRm8LKW