### PR TITLE
Fix logo to highlight 'fill' instead of 'ill'

### DIFF
--- a/docs/best_practices.html
+++ b/docs/best_practices.html
@@ -164,7 +164,7 @@ h2:first-of-type { margin-top: 0; }
 
 <header class="site-header">
   <div class="header-inner">
-    <a href="index.html" class="logo">xlf<span>ill</span>down</a>
+    <a href="index.html" class="logo">xl<span>fill</span>down</a>
     <button class="nav-toggle" onclick="document.querySelector('nav').classList.toggle('nav-open');document.querySelector('nav').classList.toggle('nav-closed')" aria-label="Toggle navigation">
       <span></span><span></span><span></span>
     </button>
@@ -716,7 +716,7 @@ xlfilldown db \
 <footer class="site-footer">
   <div class="footer-inner">
     <div class="footer-brand">
-      <h3>xlf<span>ill</span>down</h3>
+      <h3>xl<span>fill</span>down</h3>
       <p>A Python library for filling down values in .xlsx spreadsheets (OOXML).</p>
     </div>
     <div class="footer-links">

--- a/docs/index.html
+++ b/docs/index.html
@@ -651,7 +651,7 @@ code.inline {
 <!-- Header -->
 <header class="site-header">
   <div class="header-inner">
-    <a href="index.html" class="logo">xlf<span>ill</span>down</a>
+    <a href="index.html" class="logo">xl<span>fill</span>down</a>
     <button class="nav-toggle" onclick="document.querySelector('nav').classList.toggle('nav-open');document.querySelector('nav').classList.toggle('nav-closed')" aria-label="Toggle navigation">
       <span></span><span></span><span></span>
     </button>
@@ -1048,7 +1048,7 @@ summary = <span class="fn">ingest_excel_to_sqlite</span>(
 <footer class="site-footer">
   <div class="footer-inner">
     <div class="footer-brand">
-      <h3>xlf<span>ill</span>down</h3>
+      <h3>xl<span>fill</span>down</h3>
       <p>A Python library for filling down values in .xlsx spreadsheets (OOXML). Stream into SQLite or a new Excel sheet with forward-fill padding, preserved row numbers, and stable SHA-256 row hashes.</p>
     </div>
     <div class="footer-links">

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -138,7 +138,7 @@ pre.code-block {
 
 <header class="site-header">
   <div class="header-inner">
-    <a href="index.html" class="logo">xlf<span>ill</span>down</a>
+    <a href="index.html" class="logo">xl<span>fill</span>down</a>
     <button class="nav-toggle" onclick="document.querySelector('nav').classList.toggle('nav-open');document.querySelector('nav').classList.toggle('nav-closed')" aria-label="Toggle navigation">
       <span></span><span></span><span></span>
     </button>
@@ -594,7 +594,7 @@ APAC       Japan      Tokyo</pre>
 <footer class="site-footer">
   <div class="footer-inner">
     <div class="footer-brand">
-      <h3>xlf<span>ill</span>down</h3>
+      <h3>xl<span>fill</span>down</h3>
       <p>A Python library for filling down values in .xlsx spreadsheets (OOXML).</p>
     </div>
     <div class="footer-links">


### PR DESCRIPTION
Change the blue accent in the logo from xlf[ill]down to xl[fill]down so the core concept 'fill-down' is immediately visible in the branding.

https://claude.ai/code/session_01EAwPBzteNK5gfRnuRm8LKW